### PR TITLE
fix(docs): resolve broken links in docs-site

### DIFF
--- a/docs-site/docs/event-sourcing/observability/index.md
+++ b/docs-site/docs/event-sourcing/observability/index.md
@@ -1,6 +1,6 @@
 # Observability
 
-The observability module provides tracing, metrics, and structured logging for Event Sourcing applications. It follows conventions from [ADR-017](/docs/adrs/ADR-017-observability-conventions.md).
+The observability module provides tracing, metrics, and structured logging for Event Sourcing applications. It follows conventions from ADR-017 (Observability Conventions).
 
 ## Quick Start
 

--- a/docs-site/docs/event-sourcing/observability/runbooks/failed-events.md
+++ b/docs-site/docs/event-sourcing/observability/runbooks/failed-events.md
@@ -295,6 +295,6 @@ groups:
 
 ## Related
 
-- [Failure Handling](../projections/failure-handling.md)
+- [Failure Handling](../../projections/failure-handling.md)
 - [Projection Lag Runbook](./projection-lag.md)
-- [Rebuilding Projections](../projections/rebuilding.md)
+- [Rebuilding Projections](../../projections/rebuilding.md)

--- a/docs-site/docs/event-sourcing/observability/runbooks/projection-lag.md
+++ b/docs-site/docs/event-sourcing/observability/runbooks/projection-lag.md
@@ -250,6 +250,6 @@ Key panels:
 
 ## Related
 
-- [Projection Failure Handling](../projections/failure-handling.md)
-- [Rebuilding Projections](../projections/rebuilding.md)
-- [Health Monitoring](../projections/health-monitoring.md)
+- [Projection Failure Handling](../../projections/failure-handling.md)
+- [Rebuilding Projections](../../projections/rebuilding.md)
+- [Health Monitoring](../../projections/health-monitoring.md)

--- a/docs-site/docs/event-sourcing/projections.md
+++ b/docs-site/docs/event-sourcing/projections.md
@@ -525,4 +525,4 @@ class IndexedProjection {
 
 - Learn about Event Bus for cross-aggregate communication
 - Explore CQRS patterns that leverage projections
-- See [Examples](./examples/) for projection implementations in action
+- See [Examples](../examples/) for projection implementations in action


### PR DESCRIPTION
## Summary
Fixes broken links that caused the docs deployment to fail.

## Changes
- Remove ADR-017 link (ADRs are external to docs-site)
- Fix relative paths from runbooks to projections (`../../` not `../`)
- Fix examples link in projections.md (`../examples/` not `./examples/`)

## Test Plan
- [ ] Docs site builds successfully