### PR TITLE
fix(docs): remove broken examples link from projections.md

### DIFF
--- a/docs-site/docs/event-sourcing/projections.md
+++ b/docs-site/docs/event-sourcing/projections.md
@@ -525,4 +525,4 @@ class IndexedProjection {
 
 - Learn about Event Bus for cross-aggregate communication
 - Explore CQRS patterns that leverage projections
-- See [Examples](../examples/) for projection implementations in action
+- See the Examples section for projection implementations in action

--- a/docs-site/static/api-docs-llm.txt
+++ b/docs-site/static/api-docs-llm.txt
@@ -1,5 +1,5 @@
 === EVENT SOURCING PLATFORM API REFERENCE ===
-Generated: 2025-11-05T20:01:41.783Z
+Generated: 2025-12-19T21:05:42.938Z
 Format: Plain Text (LLM-optimized)
 
 This document contains comprehensive API documentation for the Event Sourcing Platform,
@@ -5350,7 +5350,7 @@ class IndexedProjection {
 
 - Learn about Event Bus for cross-aggregate communication
 - Explore CQRS patterns that leverage projections
-- See Examples for projection implementations in action
+- See the Examples section for projection implementations in action
 
 
 ================================================================================


### PR DESCRIPTION
Fixes docs build failure. The `./examples/` link is resolved incorrectly by Docusaurus because `projections.md` and `projections/index.md` compete for the same route.