### PR TITLE
fix(event-store): correct Dockerfile FROM stage casing

### DIFF
--- a/event-store/Dockerfile
+++ b/event-store/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage build for Event Store
 # Stage 1: Build the Rust binary
-FROM rust:1.82-slim as builder
+FROM rust:1.82-slim AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Fixes Docker BuildKit warning by changing `as` to `AS` in multi-stage build.

## Changes
- Change `FROM rust:1.82-slim as builder` to `FROM rust:1.82-slim AS builder`

## Why
Docker BuildKit emits a warning when the casing of `FROM` and `as` keywords don't match. Using uppercase `AS` is the standard convention.

## Testing
- ✅ Docker build completes without casing warnings