### PR TITLE
fix(vsa-visualizer): separate tsconfig for IDE and build

### DIFF
--- a/vsa/vsa-visualizer/package.json
+++ b/vsa/vsa-visualizer/package.json
@@ -7,7 +7,7 @@
     "vsa-visualizer": "dist/index.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "test": "jest",
     "type-check": "tsc --noEmit",
     "dev": "ts-node src/index.ts",

--- a/vsa/vsa-visualizer/tsconfig.build.json
+++ b/vsa/vsa-visualizer/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/vsa/vsa-visualizer/tsconfig.json
+++ b/vsa/vsa-visualizer/tsconfig.json
@@ -3,19 +3,15 @@
     "target": "ES2020",
     "module": "commonjs",
     "lib": ["ES2020"],
-    "outDir": "./dist",
-    "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "declaration": true,
-    "declarationMap": true,
     "sourceMap": true,
     "moduleResolution": "node",
     "types": ["node", "jest"]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

Fixes IDE errors for Jest types in test files by using separate TypeScript configs.

## Changes

- `tsconfig.json`: IDE support with `tests/**/*` included, no `rootDir` constraint
- `tsconfig.build.json`: Production build with `rootDir`/`outDir`/`declaration`
- `package.json`: Build script uses `tsconfig.build.json`

## Why

The original `tsconfig.json` excluded `tests/` to keep them out of `dist/`, but this caused IDE errors:
```
Cannot find name 'describe'. Do you need to install type definitions for a test runner?
```

This pattern (separate IDE and build configs) is the recommended approach used by TypeScript, Prisma, and other projects.

## Test Plan

- [x] `pnpm build` produces correct output (dist/index.js, not dist/src/index.js)
- [x] `pnpm test` passes (116 tests)
- [x] IDE recognizes Jest types in test files