### PR TITLE
ci: add symlink to VSA workflow

### DIFF
--- a/.github/workflows/vsa-ci.yml
+++ b/.github/workflows/vsa-ci.yml
@@ -1,0 +1,1 @@
+../../vsa/.github/workflows/ci.yml


### PR DESCRIPTION
## Summary

- Adds a symlink from `.github/workflows/vsa-ci.yml` to `vsa/.github/workflows/ci.yml`
- This allows the VSA CI workflow to be discovered and executed by GitHub Actions when running in the event-sourcing-platform repository
- Keeps the canonical workflow file co-located with the VSA codebase

## Test plan

- [ ] Verify symlink resolves correctly on Linux runners
- [ ] Confirm VSA CI jobs run on push/PR to main