### PR TITLE
feat(vsa): improve slice.yaml detection and restructure diagram context boxes

### DIFF
--- a/vsa/vsa-core/src/manifest.rs
+++ b/vsa/vsa-core/src/manifest.rs
@@ -285,7 +285,8 @@ impl Manifest {
     ///
     /// Detection priority:
     /// 1. Explicit `type:` field in slice.yaml (command, query, saga, mixed)
-    /// 2. Implicit from slice.yaml structure (`query:` key → query, `command:` key → command)
+    /// 2. Implicit from slice.yaml structure keys (`query:`, `command:`,
+    ///    `projection:`, `read_model:`)
     /// 3. File name patterns (*Command.*, *Query.*, *Projection.*, projection.*)
     fn detect_slice_type(feature_path: &Path, file_names: &[String]) -> SliceType {
         // 1. Try slice.yaml first
@@ -297,7 +298,24 @@ impl Manifest {
         Self::detect_slice_type_from_files(file_names)
     }
 
-    /// Try to detect slice type from slice.yaml or slice.yml
+    /// Try to detect slice type from slice.yaml or slice.yml.
+    ///
+    /// Supports two slice.yaml formats:
+    ///
+    /// **Format 1 (explicit type):**
+    /// ```yaml
+    /// name: trigger_history
+    /// type: query
+    /// ```
+    ///
+    /// **Format 2 (section keys):**
+    /// ```yaml
+    /// name: list_repos
+    /// query:
+    ///   name: ListAccessibleReposQuery
+    /// read_model:
+    ///   name: AccessibleRepository
+    /// ```
     fn detect_slice_type_from_yaml(feature_path: &Path) -> Option<SliceType> {
         let yaml_path = feature_path.join("slice.yaml");
         let yml_path = feature_path.join("slice.yml");
@@ -310,14 +328,35 @@ impl Manifest {
             return None;
         };
 
-        let content = fs::read_to_string(&path).ok()?;
+        let content = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!(
+                    "  ⚠ Warning: could not read {}: {}",
+                    path.display(),
+                    e
+                );
+                return None;
+            }
+        };
 
-        // Try to parse as YAML value to check for type field and section keys
-        let yaml: serde_yaml::Value = serde_yaml::from_str(&content).ok()?;
+        let yaml: serde_yaml::Value = match serde_yaml::from_str(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!(
+                    "  ⚠ Warning: could not parse {}: {}",
+                    path.display(),
+                    e
+                );
+                return None;
+            }
+        };
+
         let mapping = yaml.as_mapping()?;
+        let key = |s: &str| serde_yaml::Value::String(s.to_string());
 
-        // Check explicit `type:` field first
-        if let Some(type_val) = mapping.get(&serde_yaml::Value::String("type".to_string())) {
+        // Priority 1: Explicit `type:` field
+        if let Some(type_val) = mapping.get(&key("type")) {
             if let Some(type_str) = type_val.as_str() {
                 return Some(match type_str.to_lowercase().as_str() {
                     "command" => SliceType::Command,
@@ -329,17 +368,17 @@ impl Manifest {
             }
         }
 
-        // Infer from section keys: `query:` or `command:` keys
-        let has_query_key = mapping
-            .contains_key(&serde_yaml::Value::String("query".to_string()));
-        let has_command_key = mapping
-            .contains_key(&serde_yaml::Value::String("command".to_string()));
+        // Priority 2: Infer from section keys
+        let has_query = mapping.contains_key(&key("query"));
+        let has_command = mapping.contains_key(&key("command"));
+        let has_projection = mapping.contains_key(&key("projection"));
+        let has_read_model = mapping.contains_key(&key("read_model"));
 
-        if has_command_key && has_query_key {
+        if has_command && (has_query || has_projection) {
             Some(SliceType::Mixed)
-        } else if has_query_key {
+        } else if has_query || has_projection || has_read_model {
             Some(SliceType::Query)
-        } else if has_command_key {
+        } else if has_command {
             Some(SliceType::Command)
         } else {
             None // No type info in yaml, fall through to file detection
@@ -552,7 +591,7 @@ mod tests {
             "CreateOrderHandler.ts".to_string(),
             "OrderCreatedEvent.ts".to_string(),
         ];
-        assert_eq!(Manifest::detect_slice_type(&files), SliceType::Command);
+        assert_eq!(Manifest::detect_slice_type_from_files(&files), SliceType::Command);
     }
 
     #[test]
@@ -562,21 +601,21 @@ mod tests {
             "OrderListProjection.ts".to_string(),
             "ListOrdersHandler.ts".to_string(),
         ];
-        assert_eq!(Manifest::detect_slice_type(&files), SliceType::Query);
+        assert_eq!(Manifest::detect_slice_type_from_files(&files), SliceType::Query);
     }
 
     #[test]
     fn test_detect_slice_type_query_projection_only() {
         // Query slice with only projection file
         let files = vec!["OrderListProjection.py".to_string(), "handler.py".to_string()];
-        assert_eq!(Manifest::detect_slice_type(&files), SliceType::Query);
+        assert_eq!(Manifest::detect_slice_type_from_files(&files), SliceType::Query);
     }
 
     #[test]
     fn test_detect_slice_type_saga() {
         let files =
             vec!["OrderProcessingSaga.ts".to_string(), "OrderProcessingSagaHandler.ts".to_string()];
-        assert_eq!(Manifest::detect_slice_type(&files), SliceType::Saga);
+        assert_eq!(Manifest::detect_slice_type_from_files(&files), SliceType::Saga);
     }
 
     #[test]
@@ -586,13 +625,13 @@ mod tests {
             "GetOrderQuery.ts".to_string(),
             "OrderHandler.ts".to_string(),
         ];
-        assert_eq!(Manifest::detect_slice_type(&files), SliceType::Mixed);
+        assert_eq!(Manifest::detect_slice_type_from_files(&files), SliceType::Mixed);
     }
 
     #[test]
     fn test_detect_slice_type_unknown() {
         let files = vec!["utils.ts".to_string(), "helpers.ts".to_string(), "index.ts".to_string()];
-        assert_eq!(Manifest::detect_slice_type(&files), SliceType::Unknown);
+        assert_eq!(Manifest::detect_slice_type_from_files(&files), SliceType::Unknown);
     }
 
     #[test]
@@ -604,14 +643,14 @@ mod tests {
             "utils.ts".to_string(),
         ];
         // Even though test files mention Command, they should be ignored
-        assert_eq!(Manifest::detect_slice_type(&files), SliceType::Unknown);
+        assert_eq!(Manifest::detect_slice_type_from_files(&files), SliceType::Unknown);
     }
 
     #[test]
     fn test_detect_slice_type_python_files() {
         let files =
             vec!["CreateOrderCommand.py".to_string(), "create_order_handler.py".to_string()];
-        assert_eq!(Manifest::detect_slice_type(&files), SliceType::Command);
+        assert_eq!(Manifest::detect_slice_type_from_files(&files), SliceType::Command);
     }
 
     #[test]
@@ -620,7 +659,7 @@ mod tests {
             "list_orders_query.rs".to_string(), // Note: doesn't end with Query
             "OrderProjection.rs".to_string(),
         ];
-        assert_eq!(Manifest::detect_slice_type(&files), SliceType::Query);
+        assert_eq!(Manifest::detect_slice_type_from_files(&files), SliceType::Query);
     }
 
     #[test]
@@ -779,6 +818,191 @@ mod tests {
         assert_eq!(
             relationships.event_to_handlers.get("ItemRemovedEvent"),
             Some(&vec!["CartAggregate".to_string()])
+        );
+    }
+
+    // --- YAML-based slice type detection tests ---
+
+    fn write_slice_yaml(dir: &Path, content: &str) {
+        fs::write(dir.join("slice.yaml"), content).unwrap();
+    }
+
+    #[test]
+    fn test_yaml_explicit_type_query() {
+        let dir = tempfile::tempdir().unwrap();
+        write_slice_yaml(dir.path(), "name: trigger_history\ntype: query\n");
+        assert_eq!(
+            Manifest::detect_slice_type_from_yaml(dir.path()),
+            Some(SliceType::Query)
+        );
+    }
+
+    #[test]
+    fn test_yaml_explicit_type_command() {
+        let dir = tempfile::tempdir().unwrap();
+        write_slice_yaml(dir.path(), "name: create_order\ntype: command\n");
+        assert_eq!(
+            Manifest::detect_slice_type_from_yaml(dir.path()),
+            Some(SliceType::Command)
+        );
+    }
+
+    #[test]
+    fn test_yaml_explicit_type_saga() {
+        let dir = tempfile::tempdir().unwrap();
+        write_slice_yaml(dir.path(), "name: order_process\ntype: saga\n");
+        assert_eq!(
+            Manifest::detect_slice_type_from_yaml(dir.path()),
+            Some(SliceType::Saga)
+        );
+    }
+
+    #[test]
+    fn test_yaml_explicit_type_mixed() {
+        let dir = tempfile::tempdir().unwrap();
+        write_slice_yaml(dir.path(), "name: orders\ntype: mixed\n");
+        assert_eq!(
+            Manifest::detect_slice_type_from_yaml(dir.path()),
+            Some(SliceType::Mixed)
+        );
+    }
+
+    #[test]
+    fn test_yaml_explicit_type_case_insensitive() {
+        let dir = tempfile::tempdir().unwrap();
+        write_slice_yaml(dir.path(), "name: list_items\ntype: Query\n");
+        assert_eq!(
+            Manifest::detect_slice_type_from_yaml(dir.path()),
+            Some(SliceType::Query)
+        );
+    }
+
+    #[test]
+    fn test_yaml_query_section_key() {
+        let dir = tempfile::tempdir().unwrap();
+        write_slice_yaml(
+            dir.path(),
+            "name: list_repos\nquery:\n  name: ListReposQuery\n",
+        );
+        assert_eq!(
+            Manifest::detect_slice_type_from_yaml(dir.path()),
+            Some(SliceType::Query)
+        );
+    }
+
+    #[test]
+    fn test_yaml_projection_key_infers_query() {
+        let dir = tempfile::tempdir().unwrap();
+        write_slice_yaml(
+            dir.path(),
+            "name: get_installation\nprojection:\n  name: InstallationProjection\n",
+        );
+        assert_eq!(
+            Manifest::detect_slice_type_from_yaml(dir.path()),
+            Some(SliceType::Query)
+        );
+    }
+
+    #[test]
+    fn test_yaml_read_model_key_infers_query() {
+        let dir = tempfile::tempdir().unwrap();
+        write_slice_yaml(
+            dir.path(),
+            "name: get_status\nread_model:\n  name: StatusReadModel\n",
+        );
+        assert_eq!(
+            Manifest::detect_slice_type_from_yaml(dir.path()),
+            Some(SliceType::Query)
+        );
+    }
+
+    #[test]
+    fn test_yaml_command_section_key() {
+        let dir = tempfile::tempdir().unwrap();
+        write_slice_yaml(
+            dir.path(),
+            "name: place_order\ncommand:\n  name: PlaceOrderCommand\n",
+        );
+        assert_eq!(
+            Manifest::detect_slice_type_from_yaml(dir.path()),
+            Some(SliceType::Command)
+        );
+    }
+
+    #[test]
+    fn test_yaml_command_and_query_keys_infer_mixed() {
+        let dir = tempfile::tempdir().unwrap();
+        write_slice_yaml(
+            dir.path(),
+            "name: orders\ncommand:\n  name: Cmd\nquery:\n  name: Qry\n",
+        );
+        assert_eq!(
+            Manifest::detect_slice_type_from_yaml(dir.path()),
+            Some(SliceType::Mixed)
+        );
+    }
+
+    #[test]
+    fn test_yaml_no_type_info_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        write_slice_yaml(dir.path(), "name: utils\ndescription: helper slice\n");
+        assert_eq!(Manifest::detect_slice_type_from_yaml(dir.path()), None);
+    }
+
+    #[test]
+    fn test_yaml_no_file_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(Manifest::detect_slice_type_from_yaml(dir.path()), None);
+    }
+
+    #[test]
+    fn test_yaml_malformed_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        write_slice_yaml(dir.path(), "{{invalid yaml::: [[[");
+        assert_eq!(Manifest::detect_slice_type_from_yaml(dir.path()), None);
+    }
+
+    #[test]
+    fn test_yaml_slice_yml_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("slice.yml"), "name: orders\ntype: command\n").unwrap();
+        assert_eq!(
+            Manifest::detect_slice_type_from_yaml(dir.path()),
+            Some(SliceType::Command)
+        );
+    }
+
+    #[test]
+    fn test_yaml_takes_priority_over_files() {
+        let dir = tempfile::tempdir().unwrap();
+        write_slice_yaml(dir.path(), "name: list_items\ntype: query\n");
+        let files = vec!["CreateItemCommand.py".to_string()];
+        assert_eq!(
+            Manifest::detect_slice_type(dir.path(), &files),
+            SliceType::Query
+        );
+    }
+
+    #[test]
+    fn test_files_used_when_no_yaml() {
+        let dir = tempfile::tempdir().unwrap();
+        let files = vec!["CreateOrderCommand.ts".to_string()];
+        assert_eq!(
+            Manifest::detect_slice_type(dir.path(), &files),
+            SliceType::Command
+        );
+    }
+
+    #[test]
+    fn test_explicit_type_overrides_section_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        write_slice_yaml(
+            dir.path(),
+            "name: mixed_slice\ntype: command\nquery:\n  name: SomeQuery\n",
+        );
+        assert_eq!(
+            Manifest::detect_slice_type_from_yaml(dir.path()),
+            Some(SliceType::Command)
         );
     }
 }

--- a/vsa/vsa-visualizer/src/generators/architecture-svg-generator.ts
+++ b/vsa/vsa-visualizer/src/generators/architecture-svg-generator.ts
@@ -10,7 +10,7 @@
  */
 
 import { BaseGenerator } from './base-generator';
-import { Manifest, BoundedContext, Feature, SliceType } from '../types/manifest';
+import { Manifest, BoundedContext, Feature } from '../types/manifest';
 import { SvgBuilder, Point, ArchitectureColors } from '../utils/svg-builder';
 
 interface GridLayout {
@@ -294,61 +294,48 @@ export class ArchitectureSvgGenerator extends BaseGenerator {
    * Calculate required height for a context box based on its content
    */
   private calculateContextHeight(context: BoundedContext): number {
-    const features = this.filterFeatures(context.features || []);
-    const grouped = this.groupFeaturesBySliceType(features);
-    
     // Base height: header + padding
     let height = 50;
-    
-    // Add height for aggregates section
+
+    // Aggregates section
     const contextAggregates = (this.manifest.domain?.aggregates || [])
       .filter(agg => agg.context === context.name);
     if (contextAggregates.length > 0) {
-      height += this.SECTION_HEADER_HEIGHT; // "Aggregates:" header
-      height += contextAggregates.length * this.FEATURE_LINE_HEIGHT; // aggregate list
-      height += 5; // gap before features
+      height += this.SECTION_HEADER_HEIGHT;
+      height += contextAggregates.length * this.FEATURE_LINE_HEIGHT;
+      height += 5;
     }
-    
-    // Add height for each non-empty section
-    const sections: SliceType[] = ['command', 'query', 'mixed', 'unknown'];
-    for (const sliceType of sections) {
-      const sectionFeatures = grouped[sliceType] || [];
-      if (sectionFeatures.length > 0) {
-        // Section header + features
-        const maxFeatures = this.visualizeConfig.maxFeaturesPerSection;
-        const displayCount = maxFeatures 
-          ? Math.min(sectionFeatures.length, maxFeatures)
-          : sectionFeatures.length;
-        height += this.SECTION_HEADER_HEIGHT + (displayCount * this.FEATURE_LINE_HEIGHT);
-        // Add "... and X more" line if truncated
-        if (maxFeatures && sectionFeatures.length > maxFeatures) {
-          height += this.FEATURE_LINE_HEIGHT;
-        }
+
+    // Features section (flat list of all slices)
+    const features = this.filterFeatures(context.features || []);
+    if (features.length > 0) {
+      const maxFeatures = this.visualizeConfig.maxFeaturesPerSection;
+      const displayCount = maxFeatures
+        ? Math.min(features.length, maxFeatures)
+        : features.length;
+      height += this.SECTION_HEADER_HEIGHT + (displayCount * this.FEATURE_LINE_HEIGHT);
+      if (maxFeatures && features.length > maxFeatures) {
+        height += this.FEATURE_LINE_HEIGHT;
       }
     }
-    
+
+    // Commands section
+    const contextCommands = (this.manifest.domain?.commands || [])
+      .filter(cmd => cmd.context === context.name);
+    if (contextCommands.length > 0) {
+      height += this.SECTION_HEADER_HEIGHT + (contextCommands.length * this.FEATURE_LINE_HEIGHT);
+    }
+
+    // Events section
+    const contextEvents = (this.manifest.domain?.events || [])
+      .filter(evt => evt.context === context.name);
+    if (contextEvents.length > 0) {
+      height += this.SECTION_HEADER_HEIGHT + (contextEvents.length * this.FEATURE_LINE_HEIGHT);
+    }
+
     // Ensure minimum height
     const minHeight = this.visualizeConfig.minContextHeight || this.MIN_CONTEXT_HEIGHT;
     return Math.max(height, minHeight);
-  }
-
-  /**
-   * Group features by their slice type
-   */
-  private groupFeaturesBySliceType(features: Feature[]): Record<SliceType, Feature[]> {
-    const grouped: Record<SliceType, Feature[]> = {
-      command: [],
-      query: [],
-      mixed: [],
-      unknown: []
-    };
-    
-    for (const feature of features) {
-      const sliceType = feature.slice_type || 'unknown';
-      grouped[sliceType].push(feature);
-    }
-    
-    return grouped;
   }
 
   /**
@@ -411,18 +398,6 @@ export class ArchitectureSvgGenerator extends BaseGenerator {
     return totalHeight;
   }
   
-  /**
-   * Get slice type section label with emoji
-   */
-  private getSliceTypeSectionLabel(sliceType: SliceType): string {
-    switch (sliceType) {
-      case 'command': return '⚡ Commands';
-      case 'query': return '📊 Queries';
-      case 'mixed': return '🔀 Mixed';
-      case 'unknown': return '⚡ Commands';
-    }
-  }
-
   /**
    * Render a single context box
    */
@@ -505,22 +480,14 @@ export class ArchitectureSvgGenerator extends BaseGenerator {
       currentY += 5; // Small gap before features
     }
     
-    // Group features by slice type
+    // Features section (flat list of all slices)
     const features = this.filterFeatures(context.features || []);
-    const grouped = this.groupFeaturesBySliceType(features);
-    
     const maxFeaturesPerSection = this.visualizeConfig.maxFeaturesPerSection;
-    
-    // Render each non-empty slice type section
-    const sliceTypes: SliceType[] = ['command', 'query', 'mixed', 'unknown'];
-    for (const sliceType of sliceTypes) {
-      const sectionFeatures = grouped[sliceType];
-      if (sectionFeatures.length === 0) continue;
-      
-      // Section header
+
+    if (features.length > 0) {
       svg.text(
         { x: pos.x + 15, y: currentY },
-        this.getSliceTypeSectionLabel(sliceType),
+        '📋 Features',
         {
           fontSize: this.FONT_SIZE_FEATURE,
           fontWeight: '600',
@@ -529,12 +496,11 @@ export class ArchitectureSvgGenerator extends BaseGenerator {
         }
       );
       currentY += this.SECTION_HEADER_HEIGHT;
-      
-      // List features
-      const displayFeatures = maxFeaturesPerSection 
-        ? sectionFeatures.slice(0, maxFeaturesPerSection)
-        : sectionFeatures;
-      
+
+      const displayFeatures = maxFeaturesPerSection
+        ? features.slice(0, maxFeaturesPerSection)
+        : features;
+
       displayFeatures.forEach(feature => {
         svg.text(
           { x: pos.x + 20, y: currentY },
@@ -547,12 +513,11 @@ export class ArchitectureSvgGenerator extends BaseGenerator {
         );
         currentY += this.FEATURE_LINE_HEIGHT;
       });
-      
-      // Show "... and X more" if truncated
-      if (maxFeaturesPerSection && sectionFeatures.length > maxFeaturesPerSection) {
+
+      if (maxFeaturesPerSection && features.length > maxFeaturesPerSection) {
         svg.text(
           { x: pos.x + 20, y: currentY },
-          `• ... and ${sectionFeatures.length - maxFeaturesPerSection} more`,
+          `• ... and ${features.length - maxFeaturesPerSection} more`,
           {
             fontSize: this.FONT_SIZE_FEATURE,
             fontFamily: this.FONT_HEADER,
@@ -561,6 +526,70 @@ export class ArchitectureSvgGenerator extends BaseGenerator {
         );
         currentY += this.FEATURE_LINE_HEIGHT;
       }
+    }
+
+    // Commands section (from domain.commands filtered by context)
+    const contextCommands = (this.manifest.domain?.commands || [])
+      .filter(cmd => cmd.context === context.name)
+      .map(cmd => cmd.name.replace(/Command$/, ''));
+
+    if (contextCommands.length > 0) {
+      svg.text(
+        { x: pos.x + 15, y: currentY },
+        '⚡ Commands',
+        {
+          fontSize: this.FONT_SIZE_FEATURE,
+          fontWeight: '600',
+          fontFamily: this.FONT_HEADER,
+          fill: this.colors.text.secondary
+        }
+      );
+      currentY += this.SECTION_HEADER_HEIGHT;
+
+      contextCommands.forEach(cmdName => {
+        svg.text(
+          { x: pos.x + 20, y: currentY },
+          `• ${cmdName}`,
+          {
+            fontSize: this.FONT_SIZE_FEATURE,
+            fontFamily: this.FONT_HEADER,
+            fill: this.colors.text.primary
+          }
+        );
+        currentY += this.FEATURE_LINE_HEIGHT;
+      });
+    }
+
+    // Events section (from domain.events filtered by context)
+    const contextEvents = (this.manifest.domain?.events || [])
+      .filter(evt => evt.context === context.name)
+      .map(evt => evt.name.replace(/Event$/, ''));
+
+    if (contextEvents.length > 0) {
+      svg.text(
+        { x: pos.x + 15, y: currentY },
+        '📨 Events',
+        {
+          fontSize: this.FONT_SIZE_FEATURE,
+          fontWeight: '600',
+          fontFamily: this.FONT_HEADER,
+          fill: this.colors.text.secondary
+        }
+      );
+      currentY += this.SECTION_HEADER_HEIGHT;
+
+      contextEvents.forEach(evtName => {
+        svg.text(
+          { x: pos.x + 20, y: currentY },
+          `• ${evtName}`,
+          {
+            fontSize: this.FONT_SIZE_FEATURE,
+            fontFamily: this.FONT_HEADER,
+            fill: this.colors.text.primary
+          }
+        );
+        currentY += this.FEATURE_LINE_HEIGHT;
+      });
     }
   }
   

--- a/vsa/vsa-visualizer/src/types/manifest.ts
+++ b/vsa/vsa-visualizer/src/types/manifest.ts
@@ -107,6 +107,7 @@ export interface Command {
   target_aggregate?: string;
   has_aggregate_id: boolean;
   fields: Field[];
+  context?: string;                 // NEW in v2.3.0 - bounded context this command belongs to
 }
 
 export interface Event {
@@ -118,6 +119,7 @@ export interface Event {
   handled_by: string[];
   fields: Field[];
   decorator_present: boolean;
+  context?: string;                 // NEW in v2.3.0 - bounded context this event belongs to
 }
 
 export interface Field {


### PR DESCRIPTION
## Summary

- **Manifest generator reads `slice.yaml`** before falling back to file-name pattern detection. Three-tier priority: explicit `type:` field → implicit section keys (`query:`, `projection:`, `read_model:`, `command:`) → file naming conventions
- **Restructured diagram context boxes** to show four clear sections per bounded context: Aggregates, Features (flat list), Commands (from `domain.commands`), Events (from `domain.events`). Replaces the old slice_type grouping (Queries/Commands/Mixed/Unknown) which was fragile and hid the real value
- **Reverted `*Handler` → command detection** since diagram no longer depends on slice_type classification
- **Added `context` field** to Command/Event TypeScript types (matching what Rust already emits)
- **Better error handling** in YAML parsing with `eprintln!` warnings instead of silent `.ok()?`

## Copilot review comments (addressed)

All 6 Copilot comments from the first commit are resolved in the second commit:
- `query:`/`command:` key detection expanded to include `projection:` and `read_model:`
- Test coverage added (29 manifest tests pass, including YAML detection)
- Silent error swallowing replaced with warning output
- Unknown → "Commands" label removed entirely (no more slice_type grouping in diagram)

## Test plan

- [x] `cargo test --package vsa-core -- manifest::tests` — 29 tests pass
- [x] `npx tsc --noEmit` — TypeScript type-checks clean
- [x] `just diagram` — generates SVG with new layout
- [x] Visual inspection: each context shows Aggregates, Features, Commands, Events
- [x] GitHub context shows trigger-related features, commands, and events correctly