### PR TITLE
chore: gitignore .agentic/ session artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -285,3 +285,6 @@ examples/009-web-dashboard-ts/public/temp/
 .env.production.local
 # POC worktrees
 worktrees/
+
+# Agentic session artifacts (written by Claude CLI / agentic-primitives)
+.agentic/


### PR DESCRIPTION
## Summary

- Add `.agentic/` to `.gitignore` — these are agent session artifacts written by Claude CLI / agentic-primitives that shouldn't be tracked