### PR TITLE
fix(python-sdk): widen aggregate event methods from TEvent to DomainEvent

### DIFF
--- a/event-sourcing/python/src/event_sourcing/core/aggregate.py
+++ b/event-sourcing/python/src/event_sourcing/core/aggregate.py
@@ -248,7 +248,7 @@ class AggregateRoot(BaseAggregate[TEvent]):
             try:
                 attr = getattr(cls, name)
                 if callable(attr) and hasattr(attr, "_event_type"):
-                    event_type: str = attr._event_type  # type: ignore[union-attr]  # dynamic decorator attribute
+                    event_type: str = attr._event_type
                     handlers[event_type] = attr
             except AttributeError:
                 # Skip attributes that can't be accessed
@@ -273,7 +273,7 @@ class AggregateRoot(BaseAggregate[TEvent]):
             try:
                 attr = getattr(cls, name)
                 if callable(attr) and hasattr(attr, "_command_type"):
-                    command_type: str = attr._command_type  # type: ignore[union-attr]  # dynamic decorator attribute
+                    command_type: str = attr._command_type
                     handlers[command_type] = name
             except AttributeError:
                 continue

--- a/event-sourcing/python/src/event_sourcing/decorators/commands.py
+++ b/event-sourcing/python/src/event_sourcing/decorators/commands.py
@@ -64,7 +64,7 @@ def aggregate(aggregate_type: str | None = None) -> Callable[[T], T]:
 
     def decorator(cls: T) -> T:
         # Attach metadata to the class
-        cls._aggregate_type = aggregate_type or cls.__name__  # type: ignore[union-attr]  # dynamic decorator attribute
+        cls._aggregate_type = aggregate_type or cls.__name__
         return cls
 
     return decorator


### PR DESCRIPTION
## Summary

- Widen `apply_event`, `_raise_event`, `_apply`, `_handle_unknown_event`, `_get_event_type`, `rehydrate`, `get_uncommitted_events` from `TEvent` to `DomainEvent` — aggregates emit multiple event types, not just the creation event
- Fix `@aggregate` decorator to use `Callable[[T], T]` preserving class identity (was erasing to `type[Any]`, causing 20 pyright "UnionType" errors downstream)
- Fix `_get_event_handlers` return type to `Callable[..., Any]` for dynamic dispatch

## Context

Part of syntropic137 ISS-174 (switch from mypy to pyright). The `TEvent` constraint forced 35 `# type: ignore[arg-type]` comments across all aggregate `_apply()` calls. The `@aggregate` decorator returning `type[Any]` caused pyright to lose class identity for all decorated aggregates.

## Test plan

- [x] `uv run pyright` passes in event-sourcing-platform
- [x] `uv run pyright` passes in syntropic137 (0 errors)
- [x] 1365 tests pass in syntropic137