### PR TITLE
fix(ci): resolve VSA CI workflow name collision

### DIFF
--- a/vsa/.github/workflows/ci.yml
+++ b/vsa/.github/workflows/ci.yml
@@ -1,10 +1,16 @@
-name: CI
+name: VSA CI
 
 on:
   push:
-    branches: [ main, feat/vertical-slice-manager ]
+    branches: [main]
+    paths: [vsa/**]
   pull_request:
-    branches: [ main ]
+    branches: [main]
+    paths: [vsa/**]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,80 +20,89 @@ jobs:
   test:
     name: Test Suite
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: vsa
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable]
-    
+
     steps:
-      - uses: actions/checkout@v4
-      
+      - uses: actions/checkout@v6
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
-      
+
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
           path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      
+          key: ${{ runner.os }}-vsa-cargo-registry-${{ hashFiles('vsa/Cargo.lock') }}
+
       - name: Cache cargo index
         uses: actions/cache@v4
         with:
           path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
-      
+          key: ${{ runner.os }}-vsa-cargo-git-${{ hashFiles('vsa/Cargo.lock') }}
+
       - name: Cache cargo build
         uses: actions/cache@v4
         with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-      
+          path: vsa/target
+          key: ${{ runner.os }}-vsa-cargo-build-${{ hashFiles('vsa/Cargo.lock') }}
+
       - name: Check formatting
         run: cargo fmt --all -- --check
-      
+
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
-      
+
       - name: Build
         run: cargo build --verbose --all-features
-      
+
       - name: Run tests
         run: cargo test --verbose --all-features
 
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: vsa
     steps:
-      - uses: actions/checkout@v4
-      
+      - uses: actions/checkout@v6
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-      
+
       - name: Install tarpaulin
         run: cargo install cargo-tarpaulin
-      
+
       - name: Generate coverage
         run: cargo tarpaulin --verbose --all-features --workspace --timeout 120 --out xml
-      
+
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
-          files: ./cobertura.xml
+          files: vsa/cobertura.xml
           fail_ci_if_error: false
 
   security:
     name: Security Audit
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: vsa
     steps:
-      - uses: actions/checkout@v4
-      
+      - uses: actions/checkout@v6
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-      
+
       - name: Run cargo audit
         uses: rustsec/audit-check@v2
         with:


### PR DESCRIPTION
## Summary
- Renamed VSA CI workflow from `name: CI` to `name: VSA CI` to fix duplicate name collision with the main CI workflow, which caused GitHub Actions to fail with "workflow file issue"
- Scoped triggers to `vsa/**` paths so it only runs on VSA changes
- Added `working-directory: vsa` defaults so cargo commands target the correct workspace
- Updated action versions (checkout v4→v6, codecov v4→v5)
- Added concurrency group to match main CI pattern

## Test plan
- [ ] Verify VSA CI workflow triggers and passes on this PR
- [ ] Confirm main CI workflow is unaffected