### PR TITLE
fix(vsa): allow version 2 in VS Code extension schema

### DIFF
--- a/vsa/vscode-extension/schemas/vsa-schema.json
+++ b/vsa/vscode-extension/schemas/vsa-schema.json
@@ -14,7 +14,8 @@
       "description": "Configuration version",
       "default": 1,
       "enum": [
-        1
+        1,
+        2
       ]
     },
     "language": {


### PR DESCRIPTION
## Summary

- Adds `2` to the allowed values in `vsa-schema.json` version enum
- Fixes VS Code showing "1 error" when opening `vsa.yaml` files that use `version: 2`

## Context

The VSA tool supports version 2 configs (auto-discovery, `architecture` field) but the VS Code extension schema only permitted `version: 1`, causing false validation errors.