### PR TITLE
ci: add release container workflow for event-store image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,8 +2,9 @@
 target/
 **/target/
 
-# Cargo lock for libraries
-**/Cargo.lock
+# Note: Cargo.lock files are NOT excluded — they are required for reproducible
+# Docker builds. The original exclusion was for library convention but the
+# event-store binary needs pinned dependency versions.
 
 # IDE files
 .vscode/

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -95,11 +95,11 @@ jobs:
             echo "major_minor=$MAJOR_MINOR" >> "$GITHUB_OUTPUT"
           fi
 
-          # Don't tag 'latest' for pre-releases or dev builds
-          if [[ "$VERSION" == "dev" ]] || [[ "$VERSION" == *"-"* ]]; then
-            echo "is_stable=false" >> "$GITHUB_OUTPUT"
-          else
+          # Only tag 'latest' for valid stable semver releases
+          if [[ "$SEMVER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "is_stable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_stable=false" >> "$GITHUB_OUTPUT"
           fi
 
       # -----------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -545,19 +545,20 @@ dev: dev-start
 REGISTRY := ghcr.io/syntropic137
 IMAGE := event-store
 VERSION ?= dev
+GHCR_USER ?= $(shell gh api user --jq .login 2>/dev/null || echo syntropic137)
 
 release-build:
-	@echo "Building $(REGISTRY)/$(IMAGE):$(VERSION)..."
+	@echo "Building $(REGISTRY)/$(IMAGE):$(VERSION) (local only)..."
 	@docker buildx inspect multiarch >/dev/null 2>&1 || docker buildx create --name multiarch
 	@docker buildx use multiarch
 	docker buildx build --platform linux/amd64,linux/arm64 \
 		-f event-store/Dockerfile \
 		-t "$(REGISTRY)/$(IMAGE):$(VERSION)" \
-		.
+		--output type=image .
 
 release-push:
 	@echo "Building and pushing $(REGISTRY)/$(IMAGE):$(VERSION)..."
-	@gh auth token | docker login ghcr.io -u syntropic137 --password-stdin
+	@gh auth token | docker login ghcr.io -u "$(GHCR_USER)" --password-stdin
 	@docker buildx inspect multiarch >/dev/null 2>&1 || docker buildx create --name multiarch
 	@docker buildx use multiarch
 	docker buildx build --platform linux/amd64,linux/arm64 \


### PR DESCRIPTION
## Summary
- Adds `release-container.yml` workflow that builds and publishes the event-store Docker image to `ghcr.io/syntropic137/event-store`
- Multi-arch (linux/amd64 + linux/arm64) with cosign signing, SBOM, and SLSA provenance
- Triggers on GitHub release publish or manual dispatch (with dry-run support)
- Eliminates the ~15-20 min Rust cross-compile from syntropic137's release pipeline — it can pull the pre-built image instead

## Security
- All actions SHA-pinned (ISS-259)
- Least-privilege permissions
- cosign keyless signing (Sigstore OIDC)
- GHA build cache for faster rebuilds

## Test plan
- [ ] Merge PR and run workflow via manual dispatch with `dry_run: true` to validate the build
- [ ] Run manual dispatch with version `dev` (no dry run) to push a test image
- [ ] Verify image: `docker pull ghcr.io/syntropic137/event-store:dev`
- [ ] Create a release to test the full flow (version tags + cosign signing)
- [ ] Update syntropic137 `release-containers.yaml` to remove event-store from the build matrix