### PR TITLE
chore(ci): disable auto-publish on release until configured

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,11 @@
+# DISABLED: Package publishing not yet configured (tokens, versioning strategy).
+# Tracked in https://github.com/syntropic137/event-sourcing-platform/issues/246
+# Re-enable the release trigger once publishing is set up.
 name: Publish to GitHub Packages
 
 on:
-  release:
-    types: [created]
+  # release:
+  #   types: [created]
   workflow_dispatch:
     inputs:
       dry-run:


### PR DESCRIPTION
## Summary
- Disables the `release` trigger on `publish.yml` — it was firing on every release and failing because npm/PyPI tokens and versioning aren't set up yet
- Manual `workflow_dispatch` still works for testing when ready
- Tracked in #246 (Scale & Vision milestone)

## Test plan
- [x] Next release won't trigger the publish workflow
- [x] Manual dispatch still available