### PR TITLE
feat: ProcessManager, DispatchContext, replay safety (ADR-025)

### DIFF
--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -24,19 +24,18 @@ reason = "Duplicate advisory for RUSTSEC-2026-0049 (rustls-webpki). Dev-only."
 id = "RUSTSEC-2023-0071"
 reason = "rsa crate Marvin Attack. Dev-only dep (testcontainers → bollard). No fix exists. Not in production."
 
-# npm: @typescript-eslint 6.x → minimatch 9.0.3 (vscode-extension devDependency)
-# Pinned by @typescript-eslint 6.x. Fix: upgrade to @typescript-eslint 8.x (breaking).
+# Rust: sqlx-postgres 0.8.6 → rand 0.8.5, portpicker 0.1.1 → rand 0.8.5
+# RUSTSEC-2026-0097: unsound with custom logger using rand::rng(). Severity: LOW.
+# Requires: log + thread_rng features enabled, custom logger calling rand::rng(), reseeding.
+# sqlx uses rand internally for connection jitter - does not meet trigger conditions.
+# sqlx-postgres 0.9.0 (alpha) has rand 0.9.x but is not stable. portpicker is dev-only.
 [[IgnoredVulns]]
-id = "GHSA-23c5-xmqv-rm74"
-reason = "minimatch pinned by @typescript-eslint 6.x in vscode-extension. Awaiting eslint plugin upgrade."
+id = "RUSTSEC-2026-0097"
+reason = "rand 0.8.5 transitive dep via sqlx-postgres 0.8.6 + portpicker (dev). LOW severity, requires custom logger with rand::rng() reentrance. No stable sqlx release with rand 0.9.x."
 
 [[IgnoredVulns]]
-id = "GHSA-3ppc-4f35-3m26"
-reason = "minimatch pinned by @typescript-eslint 6.x in vscode-extension. Awaiting eslint plugin upgrade."
-
-[[IgnoredVulns]]
-id = "GHSA-7r86-cg39-jmmj"
-reason = "minimatch pinned by @typescript-eslint 6.x in vscode-extension. Awaiting eslint plugin upgrade."
+id = "GHSA-cq8v-f236-94qc"
+reason = "Duplicate advisory for RUSTSEC-2026-0097 (rand 0.8.5 unsoundness). Same justification."
 
 # npm: webpack plugins → serialize-javascript 6.0.2
 # Fix requires serialize-javascript 7.x (major), upstream plugins haven't adopted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,26 @@ The TypeScript SDK (`event-sourcing/typescript/`) provides:
 5. **Concurrency Control**: `ConcurrencyConflictError` on stale aggregate saves
 6. **Event Bus**: Cross-context communication via integration events
 
+### Event Consumer Patterns (Python SDK)
+
+The Python SDK (`event-sourcing/python/`) provides two event consumer base classes:
+
+1. **CheckpointedProjection**: Read-only event consumer for building derived views.
+   Replay-safe: replaying all events produces the same state with zero side effects.
+   `SIDE_EFFECTS_ALLOWED = False` (enforced). Use for read models, dashboards, metrics.
+
+2. **ProcessManager**: Event consumer with side effects, implementing the Processor
+   To-Do List pattern (Dilger, Ch. 37). Two parts:
+   - `handle_event()` - writes to-do records (pure, replay-safe, always called)
+   - `process_pending()` - executes pending items (idempotent, live-only, never during replay)
+   `SIDE_EFFECTS_ALLOWED = True`. Use for workflow dispatch, notifications, external API calls.
+
+3. **DispatchContext**: Passed to `handle_event()` with `is_catching_up` flag.
+   The coordinator snapshots the head `global_nonce` before subscribing to
+   determine the catch-up/live boundary.
+
+See [CONSUMER-PATTERNS.md](docs/CONSUMER-PATTERNS.md) and [ADR-025](docs/adrs/ADR-025-process-manager-pattern.md).
+
 ### Vertical Slice Architecture (VSA)
 
 The VSA tool enforces:

--- a/docs/CONSUMER-PATTERNS.md
+++ b/docs/CONSUMER-PATTERNS.md
@@ -1,0 +1,215 @@
+# Event Consumer Patterns
+
+This guide defines the two types of event consumers in ESP and the rules
+for each. Every event consumer must be exactly one of these types.
+
+## Projection (Read Model)
+
+A projection builds a derived view from events. It is **read-only** and
+**replay-safe**: running the entire event store through a projection
+1000 times must produce the same result with zero external calls.
+
+**Base class:** `CheckpointedProjection` (or `AutoDispatchProjection`)
+
+**Rules:**
+- No HTTP clients, no message publishing, no container launches
+- No imports from infrastructure or external service modules
+- `SIDE_EFFECTS_ALLOWED = False` (default)
+- Must implement: `get_name()`, `get_version()`, `get_subscribed_event_types()`, `handle_event()`
+- Returns `ProjectionResult` (SUCCESS / SKIP / FAILURE)
+- Checkpoint is saved atomically with projection data update
+
+**When to use:** Building read models, dashboards, query views, search
+indexes, or any derived state that can be rebuilt from events.
+
+**Test:** Replay the entire event store from position 0. Assert zero
+side effects, zero external calls, zero network traffic.
+
+---
+
+## ProcessManager (To-Do List Pattern)
+
+A ProcessManager reacts to events with side effects. It uses the
+Processor To-Do List pattern (Martin Dilger, *Understanding Event
+Sourcing*, Ch. 37) which splits the work into two parts with a hard
+boundary between them.
+
+**Base class:** `ProcessManager`
+
+**Two sides:**
+
+| Side | Method | When called | Side effects? |
+|------|--------|-------------|---------------|
+| Projection | `handle_event()` | Always (replay + live) | Never |
+| Processor | `process_pending()` | Live only (never during replay) | Yes (idempotent) |
+
+**Rules:**
+- `handle_event()` writes to-do records only (pure, same rules as Projection)
+- `process_pending()` executes pending items (idempotent, live-only)
+- `get_idempotency_key()` returns a stable dedup key per to-do item
+- `SIDE_EFFECTS_ALLOWED = True`
+- The coordinator enforces the boundary: `process_pending()` is never
+  called while `is_catching_up` is True
+
+**When to use:** Dispatching workflows, sending notifications, calling
+external APIs, or any action that should happen once per event and
+survive restarts.
+
+**Flow:**
+```
+Event arrives
+  -> handle_event() writes to-do record (always, replay-safe)
+  -> if live: process_pending() reads and executes pending items
+  -> process_pending() marks items as done
+  -> on crash: restart, re-read pending items, resume
+```
+
+**Test:** Replay 100 events in catch-up mode. Assert `process_pending()`
+called 0 times. Send 1 live event. Assert `process_pending()` called
+1 time.
+
+---
+
+## Decision Table
+
+| Scenario | Pattern | Example |
+|----------|---------|---------|
+| Build a read model | Projection | Order summary, dashboard metrics |
+| Build a search index | Projection | Full-text search, analytics view |
+| Dispatch a workflow on event | ProcessManager | Trigger-fired workflow dispatch |
+| Send notification on event | ProcessManager | Email, Slack, webhook notification |
+| Call external API on event | ProcessManager | GitHub status update, billing |
+| Multi-step orchestration | ProcessManager | Phase-by-phase workflow execution |
+
+---
+
+## Anti-Patterns
+
+### Projection with side effects
+
+A projection that dispatches commands, calls external APIs, or creates
+infrastructure during `handle_event()`. This is the single most
+dangerous pattern because projections run during replay.
+
+**Why it happens:** The framework only has `CheckpointedProjection` as
+a base class, so developers put side effects there.
+
+**Fix:** Use `ProcessManager` instead. The projection side writes
+to-do records. The processor side executes them.
+
+### Imperative orchestration
+
+An async function that awaits multiple steps in sequence:
+```python
+# WRONG
+async def execute(workflow):
+    for phase in workflow.phases:
+        workspace = await provision(phase)
+        result = await run_agent(workspace)
+```
+
+**Fix:** Use the ProcessManager pattern with a to-do list projection.
+The aggregate decides "what's next" via events. The processor executes
+the next step.
+
+### In-memory dedup for correctness
+
+Using `asyncio.Lock` or in-memory sets to prevent duplicate work.
+Lost on restart, doesn't work across instances.
+
+**Fix:** Use durable dedup (Postgres-backed) via `get_idempotency_key()`
+and `ExpectedVersion.NoStream`.
+
+---
+
+## DispatchContext
+
+The coordinator passes a `DispatchContext` to every `handle_event()` call:
+
+```python
+@dataclass(frozen=True)
+class DispatchContext:
+    is_catching_up: bool       # True during catch-up, False for live
+    global_nonce: int          # Position of current event
+    live_boundary_nonce: int   # Head position at subscribe time
+```
+
+- `is_catching_up = True`: historical event, replay mode
+- `is_catching_up = False`: live event, just appended to the store
+- The boundary is determined by snapshotting the head `global_nonce`
+  from the event store before subscribing
+
+Projections generally ignore the context (they are pure either way).
+ProcessManagers may use it for logging or metrics.
+
+---
+
+## Testing
+
+### Projection tests
+
+Use the existing `AutoDispatchProjection` pattern with
+`MemoryCheckpointStore`:
+
+```python
+async def test_order_summary():
+    projection = OrderSummaryProjection(store=memory_store)
+    checkpoint_store = MemoryCheckpointStore()
+    
+    result = await projection.handle_event(envelope, checkpoint_store)
+    assert result == ProjectionResult.SUCCESS
+    assert await memory_store.get("order-1") == expected_summary
+```
+
+### ProcessManager tests
+
+Use `ProcessManagerScenario`:
+
+```python
+from event_sourcing.testing import ProcessManagerScenario
+
+async def test_dispatch_manager_replay():
+    manager = WorkflowDispatchManager(store=mock_store)
+    scenario = ProcessManagerScenario(manager)
+    
+    await scenario.given_events([trigger_fired_event])
+    
+    # Projection side ran, processor side did NOT
+    assert scenario.process_pending_call_count == 0
+
+async def test_dispatch_manager_live():
+    manager = WorkflowDispatchManager(store=mock_store)
+    scenario = ProcessManagerScenario(manager)
+    
+    result = await scenario.when_live_event(trigger_fired_event)
+    
+    # Both sides ran
+    assert result == ProjectionResult.SUCCESS
+```
+
+### Idempotency tests
+
+Use `IdempotencyVerifier`:
+
+```python
+from event_sourcing.testing import IdempotencyVerifier
+
+async def test_dispatch_is_idempotent():
+    manager = WorkflowDispatchManager(store=mock_store)
+    # Set up some pending items first...
+    
+    verifier = IdempotencyVerifier(manager)
+    result = await verifier.verify(expected_first_pass=3)
+    
+    assert result.is_idempotent  # second pass processes 0 items
+```
+
+---
+
+## References
+
+- Martin Dilger, *Understanding Event Sourcing*, Ch. 37: Processor To-Do List
+- Event Modeling: https://eventmodeling.org/posts/what-is-event-modeling/
+- To-Do List + Passage of Time: https://event-driven.io/en/to_do_list_and_passage_of_time_patterns_combined/
+- ADR-025: ProcessManager Pattern (this repo)
+- ADR-014: Projection Checkpoint Architecture (this repo)

--- a/docs/PLATFORM-PHILOSOPHY.md
+++ b/docs/PLATFORM-PHILOSOPHY.md
@@ -112,6 +112,7 @@ CRUD+Events and full Event Sourcing are fundamentally different storage paradigm
 | ES SDK | Aggregates, commands, events, projections |
 | Replay Harness | Rehydrate aggregates from events |
 | Projection System | Build read models from event streams |
+| Process Manager | Event-driven side effects via To-Do List pattern |
 | Test Kit | Golden replays, invariants, projection verification |
 | Ops Tools | Checkpoints, DLQ, backfill, health checks |
 | Architecture Tool | VSA validation and enforcement |

--- a/docs/adrs/ADR-025-process-manager-pattern.md
+++ b/docs/adrs/ADR-025-process-manager-pattern.md
@@ -1,0 +1,101 @@
+# ADR-025: ProcessManager Base Class (To-Do List Pattern)
+
+**Status:** Accepted
+**Date:** 2026-04-13
+**Deciders:** Syntropic137 team
+
+## Context
+
+ESP provides `CheckpointedProjection` as the only base class for event
+consumers. This works well for read models (pure state reconstruction
+from events), but it does not support event consumers that need to produce
+side effects (dispatch workflows, call external APIs, send notifications).
+
+When a system built on ESP needs event-driven side effects, the developer
+has two options:
+
+1. Put side effects in a projection's `handle_event()` (wrong - causes
+   replay storms because projections run during catch-up replay)
+2. Build a bespoke processor with no framework support (error-prone,
+   no replay safety guarantee, inconsistent across projects)
+
+Option 1 is the path of least resistance, and it caused a critical bug
+in Syntropic137: on service restart, the subscription coordinator
+replays historical events through the dispatch projection, which
+re-dispatches workflows for already-processed PRs, burning user funds.
+
+## Decision
+
+Add a `ProcessManager` base class to ESP that implements the Processor
+To-Do List pattern (Martin Dilger, *Understanding Event Sourcing*, Ch. 37).
+
+The ProcessManager has two clearly separated parts:
+
+- **Projection side** (`handle_event()`) - writes to-do records. Called
+  during both replay and live processing. Must be pure (no side effects).
+- **Processor side** (`process_pending()`) - executes pending items.
+  Called by the coordinator ONLY for live events. Must be idempotent.
+
+The coordinator enforces the boundary: `process_pending()` is never
+called while `is_catching_up` is True.
+
+Additionally:
+- `DispatchContext` is passed to all `handle_event()` calls with
+  `is_catching_up` flag, using `global_nonce` from the event store as
+  the durable boundary
+- `CheckpointedProjection` gains `SIDE_EFFECTS_ALLOWED = False` (default)
+- `ProcessManager` overrides to `SIDE_EFFECTS_ALLOWED = True`
+- Built-in fitness functions check projection purity (whitelist-based)
+  and ProcessManager structure
+
+## Alternatives Considered
+
+### Saga pattern
+
+Sagas use compensation logic to undo failed steps in a distributed
+transaction. This adds significant complexity (compensation handlers,
+saga state machines, distributed rollback) that is unnecessary for our
+use cases. The To-Do List pattern is simpler: retry pending items on
+failure, don't compensate completed ones.
+
+### Replay flag on EventEnvelope
+
+Adding an `is_replay` field to `EventEnvelope` was considered. Rejected
+because it pushes the responsibility to each projection instead of
+enforcing it at the framework level. A projection could ignore the flag.
+The ProcessManager approach enforces the boundary structurally.
+
+### Blacklist-based purity checking
+
+Checking projections against a list of banned modules (httpx, requests,
+etc.). Rejected because blacklists are fragile - new side-effecting
+libraries slip through. The whitelist approach (projections may only
+import from allowed modules) is durable: anything not explicitly
+allowed is a violation.
+
+## Consequences
+
+### Positive
+
+- The replay storm bug becomes structurally impossible
+- Developers have a correct base class for event-driven side effects
+- The coordinator enforces the projection/processor boundary
+- Fitness functions catch violations in CI
+- Every project built on ESP inherits these guarantees
+
+### Negative
+
+- Existing projects must migrate side-effecting projections to ProcessManager
+- The coordinator becomes slightly more complex (ProcessManager detection, process_pending gating)
+- Projects must configure the whitelist for their domain modules
+
+### Neutral
+
+- ProcessManager extends CheckpointedProjection, so existing checkpoint infrastructure is reused
+- The `context` parameter on `handle_event()` is optional for backwards compatibility
+
+## References
+
+- Martin Dilger, *Understanding Event Sourcing*, Ch. 37
+- [CONSUMER-PATTERNS.md](../CONSUMER-PATTERNS.md) - full guide
+- [ADR-014](ADR-014-projection-checkpoint-architecture.md) - checkpoint architecture

--- a/event-sourcing/python/Makefile
+++ b/event-sourcing/python/Makefile
@@ -55,7 +55,7 @@ type-check:
 # Object-type ratchet: every `object` type annotation must have a OBJRATCHET justification comment.
 # New `object` usages without justification will fail CI. To reduce the count, remove the comment
 # when you replace `object` with a concrete type. See ADR-022 for rationale.
-OBJECT_RATCHET_MAX := 15
+OBJECT_RATCHET_MAX := 18
 type-ratchet:
 	@unjustified=$$(grep -rn --include='*.py' -E ':\s*object\b|-> object\b|\bobject\]|\bobject\)|\bobject,|,\s*object\b' src/ \
 		| grep -v '/proto/' \

--- a/event-sourcing/python/Makefile
+++ b/event-sourcing/python/Makefile
@@ -55,7 +55,7 @@ type-check:
 # Object-type ratchet: every `object` type annotation must have a OBJRATCHET justification comment.
 # New `object` usages without justification will fail CI. To reduce the count, remove the comment
 # when you replace `object` with a concrete type. See ADR-022 for rationale.
-OBJECT_RATCHET_MAX := 18
+OBJECT_RATCHET_MAX := 15
 type-ratchet:
 	@unjustified=$$(grep -rn --include='*.py' -E ':\s*object\b|-> object\b|\bobject\]|\bobject\)|\bobject,|,\s*object\b' src/ \
 		| grep -v '/proto/' \

--- a/event-sourcing/python/src/event_sourcing/__init__.py
+++ b/event-sourcing/python/src/event_sourcing/__init__.py
@@ -13,6 +13,7 @@ from event_sourcing.client import (
     MemoryEventStoreClient,
 )
 from event_sourcing.core.aggregate import AggregateRoot, BaseAggregate
+from event_sourcing.core.checkpoint import DispatchContext
 from event_sourcing.core.command import Command, CommandBus, CommandHandler, InMemoryCommandBus
 from event_sourcing.core.errors import (
     AggregateNotFoundError,
@@ -30,7 +31,6 @@ from event_sourcing.core.event import (
     GenericDomainEvent,
 )
 from event_sourcing.core.expected_version import ExpectedVersion
-from event_sourcing.core.checkpoint import DispatchContext
 from event_sourcing.core.process_manager import ProcessManager
 from event_sourcing.core.projection import (
     AutoDispatchProjection,

--- a/event-sourcing/python/src/event_sourcing/__init__.py
+++ b/event-sourcing/python/src/event_sourcing/__init__.py
@@ -30,6 +30,8 @@ from event_sourcing.core.event import (
     GenericDomainEvent,
 )
 from event_sourcing.core.expected_version import ExpectedVersion
+from event_sourcing.core.checkpoint import DispatchContext
+from event_sourcing.core.process_manager import ProcessManager
 from event_sourcing.core.projection import (
     AutoDispatchProjection,
     CheckpointedProjection,
@@ -82,9 +84,12 @@ __all__ = [
     # Projections (ADR-014 Checkpoint Architecture)
     "AutoDispatchProjection",
     "CheckpointedProjection",
+    "DispatchContext",
     "ProjectionCheckpoint",
     "ProjectionCheckpointStore",
     "ProjectionResult",
+    # Process Manager (To-Do List pattern)
+    "ProcessManager",
     # Checkpoint Stores
     "PostgresCheckpointStore",
     "MemoryCheckpointStore",

--- a/event-sourcing/python/src/event_sourcing/core/__init__.py
+++ b/event-sourcing/python/src/event_sourcing/core/__init__.py
@@ -3,6 +3,7 @@
 from event_sourcing.core.aggregate import AggregateRoot, BaseAggregate
 from event_sourcing.core.checkpoint import (
     CheckpointedProjection,
+    DispatchContext,
     ProjectionCheckpoint,
     ProjectionCheckpointStore,
     ProjectionResult,
@@ -10,6 +11,7 @@ from event_sourcing.core.checkpoint import (
 from event_sourcing.core.command import Command, CommandBus, CommandHandler
 from event_sourcing.core.errors import EventSourcingError
 from event_sourcing.core.event import DomainEvent, EventEnvelope, EventMetadata
+from event_sourcing.core.process_manager import ProcessManager
 from event_sourcing.core.query import Query, QueryHandler
 from event_sourcing.core.repository import Repository
 
@@ -19,9 +21,12 @@ __all__ = [
     "BaseAggregate",
     # Checkpoints (ADR-014)
     "CheckpointedProjection",
+    "DispatchContext",
     "ProjectionCheckpoint",
     "ProjectionCheckpointStore",
     "ProjectionResult",
+    # Process Manager (To-Do List pattern)
+    "ProcessManager",
     # Commands
     "Command",
     "CommandHandler",

--- a/event-sourcing/python/src/event_sourcing/core/checkpoint.py
+++ b/event-sourcing/python/src/event_sourcing/core/checkpoint.py
@@ -6,6 +6,7 @@ This module provides the core abstractions for checkpointed projections:
 - ProjectionResult: Explicit result type for event handlers
 - ProjectionCheckpointStore: Protocol for checkpoint persistence
 - CheckpointedProjection: Abstract base class with mandatory checkpoint tracking
+- DispatchContext: Replay awareness context passed by the coordinator
 
 See ADR-014 for architectural decision rationale.
 """
@@ -15,7 +16,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, ClassVar, Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
 
@@ -204,6 +205,35 @@ class ProjectionCheckpointStore(Protocol):
         ...
 
 
+@dataclass(frozen=True)
+class DispatchContext:
+    """Context passed by the SubscriptionCoordinator during event dispatch.
+
+    Provides replay awareness so projections and process managers can
+    distinguish between historical catch-up events and live events.
+
+    The coordinator snapshots the head ``global_nonce`` from the event
+    store before subscribing. Events at or below that boundary are
+    historical (catch-up); events above it are live.
+
+    Attributes:
+        is_catching_up: True during catch-up replay, False for live events.
+        global_nonce: The ``global_nonce`` of the current event (monotonic,
+            assigned by the event store at append time).
+        live_boundary_nonce: The head ``global_nonce`` snapshot taken before
+            subscribing. Events at or below this value are historical.
+    """
+
+    is_catching_up: bool
+    global_nonce: int
+    live_boundary_nonce: int
+
+    @property
+    def is_live(self) -> bool:
+        """True when processing live (non-replay) events."""
+        return not self.is_catching_up
+
+
 class CheckpointedProjection(ABC):
     """
     Abstract base class for projections with mandatory checkpoint tracking.
@@ -213,6 +243,11 @@ class CheckpointedProjection(ABC):
     2. Version number for schema evolution and rebuild detection
     3. Explicit event type filtering for performance
     4. Explicit result types (no silent failures)
+
+    Projections are **read-only** by default: they build derived state
+    from events and must never produce side effects. Replaying the entire
+    event store through a projection must yield the same result with zero
+    external calls.
 
     Subclasses MUST implement:
     - get_name(): Unique projection identifier
@@ -258,6 +293,9 @@ class CheckpointedProjection(ABC):
                     logger.error("Failed to process event", exc_info=True)
                     return ProjectionResult.FAILURE
     """
+
+    SIDE_EFFECTS_ALLOWED: ClassVar[bool] = False
+    """Projections must not produce side effects. ProcessManager overrides to True."""
 
     @abstractmethod
     def get_name(self) -> str:
@@ -305,6 +343,7 @@ class CheckpointedProjection(ABC):
         self,
         envelope: "EventEnvelope[DomainEvent]",
         checkpoint_store: ProjectionCheckpointStore,
+        context: "DispatchContext | None" = None,
     ) -> ProjectionResult:
         """
         Handle an event and update the checkpoint atomically.
@@ -321,6 +360,8 @@ class CheckpointedProjection(ABC):
         Args:
             envelope: Event envelope containing event and metadata
             checkpoint_store: Store for persisting checkpoints
+            context: Dispatch context with replay awareness. ``None`` for
+                backwards compatibility with callers that do not pass it.
 
         Returns:
             ProjectionResult.SUCCESS: Event processed, advance checkpoint
@@ -430,6 +471,7 @@ class AutoDispatchProjection(CheckpointedProjection, ABC):
         self,
         envelope: "EventEnvelope[DomainEvent]",
         checkpoint_store: "ProjectionCheckpointStore",
+        context: "DispatchContext | None" = None,
     ) -> "ProjectionResult":
         """Auto-dispatch to the matching on_* handler and save checkpoint."""
         event_type = envelope.metadata.event_type or "Unknown"

--- a/event-sourcing/python/src/event_sourcing/core/process_manager.py
+++ b/event-sourcing/python/src/event_sourcing/core/process_manager.py
@@ -98,7 +98,7 @@ class ProcessManager(CheckpointedProjection):
                     await self._store.mark_done(item)
                 return len(pending)
 
-            def get_idempotency_key(self, todo_item: dict[str, object]) -> str:  # OBJRATCHET: generic todo item schema varies per PM
+            def get_idempotency_key(self, todo_item: dict[str, str | int | float | bool | None]) -> str:
                 return str(todo_item["execution_id"])
     """
 
@@ -145,7 +145,7 @@ class ProcessManager(CheckpointedProjection):
         ...
 
     @abstractmethod
-    def get_idempotency_key(self, todo_item: dict[str, object]) -> str:  # OBJRATCHET: generic todo item schema varies per PM
+    def get_idempotency_key(self, todo_item: dict[str, str | int | float | bool | None]) -> str:
         """Return a stable dedup key for a to-do item.
 
         The key must be deterministic for the same logical work item.

--- a/event-sourcing/python/src/event_sourcing/core/process_manager.py
+++ b/event-sourcing/python/src/event_sourcing/core/process_manager.py
@@ -98,7 +98,7 @@ class ProcessManager(CheckpointedProjection):
                     await self._store.mark_done(item)
                 return len(pending)
 
-            def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+            def get_idempotency_key(self, todo_item: dict[str, object]) -> str:  # OBJRATCHET: generic todo item schema varies per PM
                 return str(todo_item["execution_id"])
     """
 
@@ -145,7 +145,7 @@ class ProcessManager(CheckpointedProjection):
         ...
 
     @abstractmethod
-    def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+    def get_idempotency_key(self, todo_item: dict[str, object]) -> str:  # OBJRATCHET: generic todo item schema varies per PM
         """Return a stable dedup key for a to-do item.
 
         The key must be deterministic for the same logical work item.

--- a/event-sourcing/python/src/event_sourcing/core/process_manager.py
+++ b/event-sourcing/python/src/event_sourcing/core/process_manager.py
@@ -1,0 +1,161 @@
+"""
+ProcessManager base class implementing the Processor To-Do List pattern.
+
+This module provides ``ProcessManager``, a base class for event consumers
+that need to produce side effects (dispatch workflows, call external APIs,
+send notifications, etc.) in response to domain events.
+
+The To-Do List pattern (Martin Dilger, *Understanding Event Sourcing*,
+Ch. 37) splits event-driven side effects into two parts with a hard
+boundary between them:
+
+1. **Projection side** (``handle_event``) -- writes to-do records to a
+   projection store. Called during both replay and live processing.
+   Must be pure: no side effects, no external calls.
+
+2. **Processor side** (``process_pending``) -- reads pending to-do
+   records and executes them. Called by the coordinator ONLY for live
+   events, never during catch-up replay. Must be idempotent.
+
+The ``SubscriptionCoordinator`` enforces the boundary: it never calls
+``process_pending()`` while ``is_catching_up`` is True.
+
+See Also:
+    - ADR-025 for the architectural decision rationale
+    - ``CheckpointedProjection`` for pure read-model projections
+    - ``DispatchContext`` for replay awareness
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING, ClassVar
+
+from event_sourcing.core.checkpoint import (
+    CheckpointedProjection,
+    ProjectionResult,
+)
+
+if TYPE_CHECKING:
+    from event_sourcing.core.checkpoint import (
+        DispatchContext,
+        ProjectionCheckpointStore,
+    )
+    from event_sourcing.core.event import DomainEvent, EventEnvelope
+
+
+class ProcessManager(CheckpointedProjection):
+    """Processor To-Do List pattern (Dilger, Ch. 37).
+
+    Two parts with a hard boundary between them:
+
+    PROJECTION SIDE (read-only, replay-safe):
+        ``handle_event()`` writes to-do records to the projection store.
+        Called during both catch-up replay and live processing.
+        MUST NOT call external services, create tasks, or dispatch work.
+
+    PROCESSOR SIDE (live-only, idempotent):
+        ``process_pending()`` reads pending records and executes them.
+        Called by the coordinator ONLY for live events, never during
+        catch-up replay. Implementations MUST be idempotent -- the same
+        item processed twice must produce the same result.
+
+    Subclasses MUST implement:
+        - ``get_name()`` -- unique projection identifier
+        - ``get_version()`` -- schema version (increment triggers rebuild)
+        - ``get_subscribed_event_types()`` -- event type filter
+        - ``handle_event()`` -- write to-do records (no side effects)
+        - ``process_pending()`` -- execute pending items (idempotent)
+        - ``get_idempotency_key()`` -- stable dedup key per to-do item
+
+    Example::
+
+        class WorkflowDispatchManager(ProcessManager):
+            def get_name(self) -> str:
+                return "workflow_dispatch"
+
+            def get_version(self) -> int:
+                return 1
+
+            def get_subscribed_event_types(self) -> set[str]:
+                return {"TriggerFiredEvent"}
+
+            async def handle_event(self, envelope, checkpoint_store, context=None):
+                # PROJECTION SIDE: write a dispatch record (to-do item)
+                await self._store.upsert(dispatch_record)
+                await checkpoint_store.save_checkpoint(...)
+                return ProjectionResult.SUCCESS
+
+            async def process_pending(self) -> int:
+                # PROCESSOR SIDE: dispatch pending workflows
+                pending = await self._store.query(status="pending")
+                for item in pending:
+                    execution_id = self.get_idempotency_key(item)
+                    if await self._execution_exists(execution_id):
+                        await self._store.mark_done(item)
+                        continue
+                    await self._dispatch_workflow(item)
+                    await self._store.mark_done(item)
+                return len(pending)
+
+            def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+                return str(todo_item["execution_id"])
+    """
+
+    SIDE_EFFECTS_ALLOWED: ClassVar[bool] = True
+    """ProcessManagers are allowed to produce side effects via process_pending()."""
+
+    @abstractmethod
+    async def handle_event(
+        self,
+        envelope: EventEnvelope[DomainEvent],
+        checkpoint_store: ProjectionCheckpointStore,
+        context: DispatchContext | None = None,
+    ) -> ProjectionResult:
+        """PROJECTION SIDE: Write to-do records. No side effects.
+
+        Called during both catch-up replay and live processing. Only
+        update the to-do list (projection store). Do not call external
+        services, create infrastructure, or dispatch work.
+
+        Args:
+            envelope: Event envelope containing the domain event.
+            checkpoint_store: Store for persisting the projection checkpoint.
+            context: Dispatch context with replay awareness.
+
+        Returns:
+            ProjectionResult indicating success, skip, or failure.
+        """
+        ...
+
+    @abstractmethod
+    async def process_pending(self) -> int:
+        """PROCESSOR SIDE: Execute pending to-do items.
+
+        Called by the coordinator ONLY for live events. Never called
+        during catch-up replay. The coordinator enforces this invariant.
+
+        Implementations MUST be idempotent: processing the same item
+        twice must produce the same result (e.g., check if the workflow
+        execution already exists before dispatching).
+
+        Returns:
+            The number of items processed.
+        """
+        ...
+
+    @abstractmethod
+    def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+        """Return a stable dedup key for a to-do item.
+
+        The key must be deterministic for the same logical work item.
+        Used by the framework and by ``process_pending()`` implementations
+        to prevent duplicate processing.
+
+        Args:
+            todo_item: The to-do record to generate a key for.
+
+        Returns:
+            A stable, content-based dedup key string.
+        """
+        ...

--- a/event-sourcing/python/src/event_sourcing/fitness/__init__.py
+++ b/event-sourcing/python/src/event_sourcing/fitness/__init__.py
@@ -1,0 +1,27 @@
+"""
+Built-in architectural fitness functions for event-sourced systems.
+
+This module ships with ESP so that any project built on the platform can
+validate architectural invariants in CI with minimal setup.
+
+Usage::
+
+    from event_sourcing.fitness import check_projection_purity, Violation
+
+    def test_projections_are_pure():
+        for path in find_projection_files():
+            violations = check_projection_purity(path)
+            assert not violations, f"{path}: {violations}"
+"""
+
+from event_sourcing.fitness.projection_purity import (
+    PROJECTION_ALLOWED_PREFIXES,
+    check_projection_purity,
+)
+from event_sourcing.fitness.violations import Violation
+
+__all__ = [
+    "PROJECTION_ALLOWED_PREFIXES",
+    "Violation",
+    "check_projection_purity",
+]

--- a/event-sourcing/python/src/event_sourcing/fitness/process_manager_check.py
+++ b/event-sourcing/python/src/event_sourcing/fitness/process_manager_check.py
@@ -1,0 +1,75 @@
+"""
+Validate ProcessManager subclasses implement the required interface.
+
+Checks that classes inheriting from ``ProcessManager`` provide all three
+required methods and have ``SIDE_EFFECTS_ALLOWED = True``.
+"""
+
+from __future__ import annotations
+
+from event_sourcing.core.process_manager import ProcessManager
+from event_sourcing.fitness.violations import Violation
+
+
+def check_process_manager(cls: type[ProcessManager]) -> list[Violation]:
+    """Validate a ProcessManager subclass implements the full interface.
+
+    Args:
+        cls: The ProcessManager subclass to validate.
+
+    Returns:
+        List of violations. Empty means the class is valid.
+    """
+    violations: list[Violation] = []
+    source_file = _get_source_file(cls)
+
+    # Check SIDE_EFFECTS_ALLOWED is True
+    if not getattr(cls, "SIDE_EFFECTS_ALLOWED", False):
+        violations.append(
+            Violation(
+                file_path=source_file,
+                line_number=0,
+                rule="process-manager-structure",
+                message=(
+                    f"{cls.__name__} has SIDE_EFFECTS_ALLOWED=False. "
+                    f"ProcessManager subclasses must allow side effects."
+                ),
+            )
+        )
+
+    # Check required methods are not still abstract
+    for method_name in ("process_pending", "get_idempotency_key"):
+        method = getattr(cls, method_name, None)
+        if method is None:
+            violations.append(
+                Violation(
+                    file_path=source_file,
+                    line_number=0,
+                    rule="process-manager-structure",
+                    message=f"{cls.__name__} is missing required method '{method_name}()'",
+                )
+            )
+        elif getattr(method, "__isabstractmethod__", False):
+            violations.append(
+                Violation(
+                    file_path=source_file,
+                    line_number=0,
+                    rule="process-manager-structure",
+                    message=(
+                        f"{cls.__name__}.{method_name}() is still abstract. "
+                        f"Provide a concrete implementation."
+                    ),
+                )
+            )
+
+    return violations
+
+
+def _get_source_file(cls: type[object]) -> str:
+    """Best-effort source file path for a class."""
+    import inspect
+
+    try:
+        return inspect.getfile(cls)
+    except (TypeError, OSError):
+        return f"<unknown: {cls.__qualname__}>"

--- a/event-sourcing/python/src/event_sourcing/fitness/process_manager_check.py
+++ b/event-sourcing/python/src/event_sourcing/fitness/process_manager_check.py
@@ -7,8 +7,12 @@ required methods and have ``SIDE_EFFECTS_ALLOWED = True``.
 
 from __future__ import annotations
 
-from event_sourcing.core.process_manager import ProcessManager
+from typing import TYPE_CHECKING
+
 from event_sourcing.fitness.violations import Violation
+
+if TYPE_CHECKING:
+    from event_sourcing.core.process_manager import ProcessManager
 
 
 def check_process_manager(cls: type[ProcessManager]) -> list[Violation]:
@@ -65,7 +69,7 @@ def check_process_manager(cls: type[ProcessManager]) -> list[Violation]:
     return violations
 
 
-def _get_source_file(cls: type[object]) -> str:
+def _get_source_file(cls: type[object]) -> str:  # OBJRATCHET: accepts any class type
     """Best-effort source file path for a class."""
     import inspect
 

--- a/event-sourcing/python/src/event_sourcing/fitness/process_manager_check.py
+++ b/event-sourcing/python/src/event_sourcing/fitness/process_manager_check.py
@@ -69,7 +69,7 @@ def check_process_manager(cls: type[ProcessManager]) -> list[Violation]:
     return violations
 
 
-def _get_source_file(cls: type[object]) -> str:  # OBJRATCHET: accepts any class type
+def _get_source_file(cls: type[ProcessManager]) -> str:
     """Best-effort source file path for a class."""
     import inspect
 

--- a/event-sourcing/python/src/event_sourcing/fitness/projection_purity.py
+++ b/event-sourcing/python/src/event_sourcing/fitness/projection_purity.py
@@ -1,0 +1,193 @@
+"""
+Whitelist-based projection purity check.
+
+Projections must be read-only: replaying the entire event store through
+a projection must yield the same result with zero external calls. This
+check enforces purity by **whitelisting** allowed imports rather than
+blacklisting dangerous ones.
+
+A blacklist is fragile -- new side-effecting libraries slip through
+undetected. A whitelist is durable: any import not explicitly allowed
+is flagged, regardless of what it is. Same principle as Content Security
+Policy (CSP) in web security: default-deny, explicit allow.
+
+Imports inside ``if TYPE_CHECKING:`` blocks are always allowed because
+they have zero runtime effect.
+
+Usage::
+
+    from event_sourcing.fitness import check_projection_purity
+
+    # With default allowed prefixes only (stdlib + event_sourcing)
+    violations = check_projection_purity(Path("my_projection.py"))
+
+    # With project-specific additions
+    violations = check_projection_purity(
+        Path("my_projection.py"),
+        allowed_prefixes={"my_domain.contexts", "my_shared"},
+    )
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from event_sourcing.fitness.violations import Violation
+
+# Default allowed module prefixes for projections.
+# These are pure stdlib modules and the ESP framework itself.
+# Projects extend this with their own domain/shared prefixes.
+PROJECTION_ALLOWED_PREFIXES: frozenset[str] = frozenset(
+    {
+        # Python stdlib (pure, no side effects)
+        "__future__",
+        "abc",
+        "collections",
+        "dataclasses",
+        "datetime",
+        "decimal",
+        "enum",
+        "functools",
+        "logging",
+        "math",
+        "operator",
+        "re",
+        "typing",
+        "typing_extensions",
+        "uuid",
+        # ESP framework itself
+        "event_sourcing",
+    }
+)
+
+
+def check_projection_purity(
+    file_path: Path,
+    allowed_prefixes: set[str] | None = None,
+) -> list[Violation]:
+    """Check that a projection file only imports from allowed modules.
+
+    Uses a whitelist approach: any runtime import whose top-level module
+    is not in the allowed set is a violation. Imports inside
+    ``if TYPE_CHECKING:`` blocks are always allowed.
+
+    Args:
+        file_path: Path to the Python projection file.
+        allowed_prefixes: Additional module prefixes to allow (merged
+            with ``PROJECTION_ALLOWED_PREFIXES``). For example,
+            ``{"syn_domain.contexts", "syn_shared"}`` to allow domain
+            imports in a Syntropic137 project.
+
+    Returns:
+        List of violations. Empty means the projection is pure.
+    """
+    source = file_path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source, filename=str(file_path))
+    except SyntaxError:
+        return [
+            Violation(
+                file_path=str(file_path),
+                line_number=0,
+                rule="projection-purity",
+                message="Could not parse file (SyntaxError)",
+            )
+        ]
+
+    all_allowed = set(PROJECTION_ALLOWED_PREFIXES)
+    if allowed_prefixes:
+        all_allowed.update(allowed_prefixes)
+
+    violations: list[Violation] = []
+    type_checking_lines = _find_type_checking_lines(tree)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if _in_type_checking_block(node.lineno, type_checking_lines):
+                    continue
+                if not _is_allowed(alias.name, all_allowed):
+                    violations.append(
+                        Violation(
+                            file_path=str(file_path),
+                            line_number=node.lineno,
+                            rule="projection-purity",
+                            message=(
+                                f"Runtime import '{alias.name}' is not in the "
+                                f"allowed whitelist for projections"
+                            ),
+                        )
+                    )
+
+        elif isinstance(node, ast.ImportFrom):
+            if node.module is None:
+                continue
+            if _in_type_checking_block(node.lineno, type_checking_lines):
+                continue
+            if not _is_allowed(node.module, all_allowed):
+                violations.append(
+                    Violation(
+                        file_path=str(file_path),
+                        line_number=node.lineno,
+                        rule="projection-purity",
+                        message=(
+                            f"Runtime import from '{node.module}' is not in the "
+                            f"allowed whitelist for projections"
+                        ),
+                    )
+                )
+
+    return violations
+
+
+def _is_allowed(module_name: str, allowed: set[str]) -> bool:
+    """Check if a module name matches any allowed prefix.
+
+    Matches if the module name equals a prefix or starts with it
+    followed by a dot. For example, prefix "event_sourcing" matches
+    "event_sourcing", "event_sourcing.core", "event_sourcing.core.checkpoint".
+    """
+    for prefix in allowed:
+        if module_name == prefix or module_name.startswith(prefix + "."):
+            return True
+    return False
+
+
+def _find_type_checking_lines(tree: ast.Module) -> list[tuple[int, int]]:
+    """Find line ranges of ``if TYPE_CHECKING:`` blocks.
+
+    Returns a list of (start_line, end_line) tuples for each
+    TYPE_CHECKING guarded block.
+    """
+    ranges: list[tuple[int, int]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+
+        # Match: if TYPE_CHECKING:
+        test = node.test
+        is_type_checking = False
+
+        if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+            is_type_checking = True
+        elif isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING":
+            is_type_checking = True
+
+        if is_type_checking:
+            start = node.lineno
+            # Find the last line in the body
+            end = start
+            for child in ast.walk(node):
+                child_lineno = getattr(child, "lineno", None)
+                if child_lineno is not None:
+                    end = max(end, child_lineno)
+            ranges.append((start, end))
+
+    return ranges
+
+
+def _in_type_checking_block(lineno: int, ranges: list[tuple[int, int]]) -> bool:
+    """Check if a line number falls within any TYPE_CHECKING block."""
+    return any(start <= lineno <= end for start, end in ranges)

--- a/event-sourcing/python/src/event_sourcing/fitness/projection_purity.py
+++ b/event-sourcing/python/src/event_sourcing/fitness/projection_purity.py
@@ -31,9 +31,12 @@ Usage::
 from __future__ import annotations
 
 import ast
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from event_sourcing.fitness.violations import Violation
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # Default allowed module prefixes for projections.
 # These are pure stdlib modules and the ESP framework itself.
@@ -122,6 +125,9 @@ def check_projection_purity(
 
         elif isinstance(node, ast.ImportFrom):
             if node.module is None:
+                continue
+            # Relative imports (level > 0) are intra-package and always allowed
+            if node.level and node.level > 0:
                 continue
             if _in_type_checking_block(node.lineno, type_checking_lines):
                 continue

--- a/event-sourcing/python/src/event_sourcing/fitness/replay_safety.py
+++ b/event-sourcing/python/src/event_sourcing/fitness/replay_safety.py
@@ -1,0 +1,95 @@
+"""
+Replay safety check for ProcessManager implementations.
+
+Verifies that ``process_pending()`` is never invoked during catch-up
+replay. This is a runtime check that uses a spy wrapper around the
+coordinator's dispatch path.
+
+Usage::
+
+    from event_sourcing.fitness.replay_safety import ReplaySafetyChecker
+
+    checker = ReplaySafetyChecker(coordinator)
+    violations = await checker.verify_replay_safety(events)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+from event_sourcing.fitness.violations import Violation
+
+if TYPE_CHECKING:
+    from event_sourcing.core.event import DomainEvent, EventEnvelope
+    from event_sourcing.core.process_manager import ProcessManager
+    from event_sourcing.subscriptions.coordinator import SubscriptionCoordinator
+
+
+class ReplaySafetyChecker:
+    """Verify that ProcessManagers do not run process_pending() during replay.
+
+    Wraps the coordinator's dispatch path and monitors all ProcessManager
+    instances for ``process_pending()`` calls while ``is_catching_up``
+    is True.
+    """
+
+    def __init__(self, coordinator: SubscriptionCoordinator) -> None:
+        self._coordinator = coordinator
+
+    async def verify_replay_safety(
+        self,
+        events: list[EventEnvelope[DomainEvent]],
+    ) -> list[Violation]:
+        """Dispatch events in catch-up mode and verify zero process_pending() calls.
+
+        Forces the coordinator into catch-up mode, dispatches all provided
+        events, and checks that no ProcessManager's ``process_pending()``
+        was called.
+
+        Args:
+            events: Events to replay through the coordinator.
+
+        Returns:
+            List of violations (one per ProcessManager that was called).
+        """
+        from event_sourcing.core.process_manager import ProcessManager
+
+        violations: list[Violation] = []
+        spies: dict[str, AsyncMock] = {}
+
+        # Patch all ProcessManager instances to spy on process_pending()
+        for name, projection in self._coordinator._projections.items():
+            if isinstance(projection, ProcessManager):
+                spy = AsyncMock(return_value=0)
+                spies[name] = spy
+
+        # Force catch-up mode
+        original_catching_up = self._coordinator._is_catching_up
+        self._coordinator._is_catching_up = True
+
+        try:
+            for name, spy in spies.items():
+                projection = self._coordinator._projections[name]
+                with patch.object(projection, "process_pending", spy):
+                    for event in events:
+                        await self._coordinator._dispatch_event(event)
+
+            # Check: no process_pending() calls during catch-up
+            for name, spy in spies.items():
+                if spy.call_count > 0:
+                    violations.append(
+                        Violation(
+                            file_path=f"<runtime:{name}>",
+                            line_number=0,
+                            rule="replay-safety",
+                            message=(
+                                f"ProcessManager '{name}' had process_pending() "
+                                f"called {spy.call_count} time(s) during catch-up replay"
+                            ),
+                        )
+                    )
+        finally:
+            self._coordinator._is_catching_up = original_catching_up
+
+        return violations

--- a/event-sourcing/python/src/event_sourcing/fitness/replay_safety.py
+++ b/event-sourcing/python/src/event_sourcing/fitness/replay_safety.py
@@ -15,6 +15,7 @@ Usage::
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
@@ -22,7 +23,6 @@ from event_sourcing.fitness.violations import Violation
 
 if TYPE_CHECKING:
     from event_sourcing.core.event import DomainEvent, EventEnvelope
-    from event_sourcing.core.process_manager import ProcessManager
     from event_sourcing.subscriptions.coordinator import SubscriptionCoordinator
 
 
@@ -64,9 +64,15 @@ class ReplaySafetyChecker:
                 spy = AsyncMock(return_value=0)
                 spies[name] = spy
 
-        # Force catch-up mode
+        # Force catch-up mode and prevent the catch-up -> live transition.
+        # Setting _is_catching_up = True alone is insufficient because
+        # _dispatch_event() flips it to live when global_nonce exceeds
+        # _live_boundary_nonce. Pin the boundary to sys.maxsize so the
+        # transition never fires during the check.
         original_catching_up = self._coordinator._is_catching_up
+        original_boundary = self._coordinator._live_boundary_nonce
         self._coordinator._is_catching_up = True
+        self._coordinator._live_boundary_nonce = sys.maxsize
 
         try:
             for name, spy in spies.items():
@@ -91,5 +97,6 @@ class ReplaySafetyChecker:
                     )
         finally:
             self._coordinator._is_catching_up = original_catching_up
+            self._coordinator._live_boundary_nonce = original_boundary
 
         return violations

--- a/event-sourcing/python/src/event_sourcing/fitness/replay_safety.py
+++ b/event-sourcing/python/src/event_sourcing/fitness/replay_safety.py
@@ -58,28 +58,28 @@ class ReplaySafetyChecker:
         violations: list[Violation] = []
         spies: dict[str, AsyncMock] = {}
 
-        # Patch all ProcessManager instances to spy on process_pending()
-        for name, projection in self._coordinator._projections.items():
+        # Identify all ProcessManager instances to spy on
+        for name, projection in self._coordinator.projections.items():
             if isinstance(projection, ProcessManager):
                 spy = AsyncMock(return_value=0)
                 spies[name] = spy
 
         # Force catch-up mode and prevent the catch-up -> live transition.
-        # Setting _is_catching_up = True alone is insufficient because
-        # _dispatch_event() flips it to live when global_nonce exceeds
-        # _live_boundary_nonce. Pin the boundary to sys.maxsize so the
+        # Setting is_catching_up = True alone is insufficient because
+        # dispatch_event() flips it to live when global_nonce exceeds
+        # live_boundary_nonce. Pin the boundary to sys.maxsize so the
         # transition never fires during the check.
-        original_catching_up = self._coordinator._is_catching_up
-        original_boundary = self._coordinator._live_boundary_nonce
-        self._coordinator._is_catching_up = True
-        self._coordinator._live_boundary_nonce = sys.maxsize
+        original_catching_up = self._coordinator.is_catching_up
+        original_boundary = self._coordinator.live_boundary_nonce
+        self._coordinator.is_catching_up = True
+        self._coordinator.live_boundary_nonce = sys.maxsize
 
         try:
             for name, spy in spies.items():
-                projection = self._coordinator._projections[name]
+                projection = self._coordinator.projections[name]
                 with patch.object(projection, "process_pending", spy):
                     for event in events:
-                        await self._coordinator._dispatch_event(event)
+                        await self._coordinator.dispatch_event(event)
 
             # Check: no process_pending() calls during catch-up
             for name, spy in spies.items():
@@ -96,7 +96,7 @@ class ReplaySafetyChecker:
                         )
                     )
         finally:
-            self._coordinator._is_catching_up = original_catching_up
-            self._coordinator._live_boundary_nonce = original_boundary
+            self._coordinator.is_catching_up = original_catching_up
+            self._coordinator.live_boundary_nonce = original_boundary
 
         return violations

--- a/event-sourcing/python/src/event_sourcing/fitness/violations.py
+++ b/event-sourcing/python/src/event_sourcing/fitness/violations.py
@@ -1,0 +1,27 @@
+"""Violation types for architectural fitness checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A single architectural fitness violation.
+
+    Attributes:
+        file_path: Path to the file containing the violation.
+        line_number: Line number of the violating code (1-indexed).
+        rule: Short rule identifier (e.g., "projection-purity").
+        message: Human-readable description of the violation.
+        severity: "error" for must-fix, "warning" for advisory.
+    """
+
+    file_path: str
+    line_number: int
+    rule: str
+    message: str
+    severity: str = "error"
+
+    def __str__(self) -> str:
+        return f"{self.file_path}:{self.line_number} [{self.rule}] {self.message}"

--- a/event-sourcing/python/src/event_sourcing/subscriptions/coordinator.py
+++ b/event-sourcing/python/src/event_sourcing/subscriptions/coordinator.py
@@ -167,6 +167,40 @@ class SubscriptionCoordinator:
         """True if the coordinator is running and has no active error."""
         return self._running and self._last_error is None
 
+    @property
+    def projections(self) -> dict[str, CheckpointedProjection]:
+        """Registered projections (name -> instance). Read-only view."""
+        return self._projections
+
+    @property
+    def is_catching_up(self) -> bool:
+        """True while replaying historical events, False for live events."""
+        return self._is_catching_up
+
+    @is_catching_up.setter
+    def is_catching_up(self, value: bool) -> None:
+        self._is_catching_up = value
+
+    @property
+    def live_boundary_nonce(self) -> int:
+        """The head global_nonce snapshot taken before subscribing."""
+        return self._live_boundary_nonce
+
+    @live_boundary_nonce.setter
+    def live_boundary_nonce(self, value: int) -> None:
+        self._live_boundary_nonce = value
+
+    async def dispatch_event(
+        self,
+        envelope: EventEnvelope[DomainEvent],
+    ) -> None:
+        """Dispatch a single event to all subscribed projections.
+
+        Public interface for testing and fitness tooling. Production
+        code uses start() which calls this internally.
+        """
+        await self._dispatch_event(envelope)
+
     async def start(self) -> None:
         """
         Start the subscription coordinator with exponential-backoff retry.

--- a/event-sourcing/python/src/event_sourcing/subscriptions/coordinator.py
+++ b/event-sourcing/python/src/event_sourcing/subscriptions/coordinator.py
@@ -19,10 +19,12 @@ from typing import TYPE_CHECKING, Protocol, TypedDict
 
 from event_sourcing.core.checkpoint import (
     CheckpointedProjection,
+    DispatchContext,
     ProjectionCheckpoint,
     ProjectionCheckpointStore,
     ProjectionResult,
 )
+from event_sourcing.core.process_manager import ProcessManager
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -61,6 +63,25 @@ class EventStoreSubscriber(Protocol):
 
         Yields:
             Event envelopes in order
+        """
+        ...
+
+    async def read_all(
+        self,
+        from_global_nonce: int = 0,
+        max_count: int = 100,
+        forward: bool = True,
+    ) -> tuple[list[EventEnvelope[DomainEvent]], bool, int]:
+        """
+        Read events from a global position (for catch-up and head detection).
+
+        Args:
+            from_global_nonce: Inclusive start position (0 = beginning)
+            max_count: Maximum events to return per page
+            forward: Direction (True = ascending, False = descending)
+
+        Returns:
+            Tuple of (events, is_end, next_from_global_nonce)
         """
         ...
 
@@ -118,6 +139,8 @@ class SubscriptionCoordinator:
         self._checkpoint_store = checkpoint_store
         self._running = False
         self._last_error: Exception | None = None
+        self._live_boundary_nonce: int = 0
+        self._is_catching_up: bool = True
 
         # Validate for duplicate projection names
         self._projections: dict[str, CheckpointedProjection] = {}
@@ -186,13 +209,34 @@ class SubscriptionCoordinator:
         Loads checkpoints, subscribes from the minimum position, and
         dispatches events until the stream ends or self._running is False.
         Clears _last_error on the first successful event dispatch.
+
+        Before subscribing, snapshots the head global_nonce from the event
+        store. Events at or below that boundary are historical (catch-up);
+        events above it are live. This is re-queried on every subscription
+        loop start for durability.
         """
         min_position = await self._get_minimum_position()
+
+        # Snapshot the head global_nonce from the event store.
+        # This is the durable catch-up/live boundary: events with
+        # global_nonce <= this value were already in the store when we
+        # subscribed and are historical. Events above are live.
+        head_events, _is_end, _next = await self._event_store.read_all(
+            from_global_nonce=0, max_count=1, forward=False,
+        )
+        if head_events and head_events[0].metadata.global_nonce is not None:
+            self._live_boundary_nonce = head_events[0].metadata.global_nonce
+        else:
+            self._live_boundary_nonce = 0
+
+        self._is_catching_up = min_position <= self._live_boundary_nonce
 
         logger.info(
             "Starting subscription",
             extra={
                 "from_position": min_position,
+                "live_boundary_nonce": self._live_boundary_nonce,
+                "is_catching_up": self._is_catching_up,
                 "projection_count": len(self._projections),
             },
         )
@@ -269,11 +313,26 @@ class SubscriptionCoordinator:
         """
         Dispatch an event to all relevant projections.
 
+        Tracks the catch-up/live transition based on global_nonce.
+
         Args:
             envelope: Event envelope to dispatch
         """
         event_type = envelope.metadata.event_type or "Unknown"
         global_nonce = envelope.metadata.global_nonce or 0
+
+        # Transition: catch-up -> live when we pass the boundary nonce.
+        # Uses > (strictly greater): events at the boundary were already
+        # in the store when we subscribed, so they are historical.
+        if self._is_catching_up and global_nonce > self._live_boundary_nonce:
+            self._is_catching_up = False
+            logger.info(
+                "Coordinator transitioned to live mode",
+                extra={
+                    "global_nonce": global_nonce,
+                    "live_boundary_nonce": self._live_boundary_nonce,
+                },
+            )
 
         for name, projection in self._projections.items():
             # Check if projection subscribes to this event type
@@ -307,8 +366,16 @@ class SubscriptionCoordinator:
         event_type = envelope.metadata.event_type or "Unknown"
         global_nonce = envelope.metadata.global_nonce or 0
 
+        context = DispatchContext(
+            is_catching_up=self._is_catching_up,
+            global_nonce=global_nonce,
+            live_boundary_nonce=self._live_boundary_nonce,
+        )
+
         try:
-            result = await projection.handle_event(envelope, self._checkpoint_store)
+            result = await projection.handle_event(
+                envelope, self._checkpoint_store, context,
+            )
 
             if result == ProjectionResult.FAILURE:
                 logger.error(
@@ -332,6 +399,26 @@ class SubscriptionCoordinator:
                 )
                 # Checkpoint should be saved by the projection itself
                 # for atomicity with data updates
+
+                # ProcessManager: run the processor side for live events only.
+                # The key invariant: process_pending() is NEVER called
+                # while is_catching_up is True.
+                if not self._is_catching_up and isinstance(projection, ProcessManager):
+                    try:
+                        processed = await projection.process_pending()
+                        if processed > 0:
+                            logger.info(
+                                "ProcessManager processed pending items",
+                                extra={
+                                    "projection_name": name,
+                                    "items_processed": processed,
+                                },
+                            )
+                    except Exception:
+                        logger.exception(
+                            "ProcessManager.process_pending() failed",
+                            extra={"projection_name": name},
+                        )
             elif result == ProjectionResult.SKIP:
                 # SKIP means the projection doesn't care about this event.
                 # We must still advance the checkpoint so it's not retried.

--- a/event-sourcing/python/src/event_sourcing/subscriptions/coordinator.py
+++ b/event-sourcing/python/src/event_sourcing/subscriptions/coordinator.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Protocol, TypedDict
 
@@ -221,8 +222,11 @@ class SubscriptionCoordinator:
         # This is the durable catch-up/live boundary: events with
         # global_nonce <= this value were already in the store when we
         # subscribed and are historical. Events above are live.
+        # Read backwards from the highest possible nonce to get the head event.
+        # from_global_nonce is inclusive: backwards reads return events with
+        # global_nonce <= from_global_nonce, so 0 would return nothing useful.
         head_events, _is_end, _next = await self._event_store.read_all(
-            from_global_nonce=0, max_count=1, forward=False,
+            from_global_nonce=sys.maxsize, max_count=1, forward=False,
         )
         if head_events and head_events[0].metadata.global_nonce is not None:
             self._live_boundary_nonce = head_events[0].metadata.global_nonce

--- a/event-sourcing/python/src/event_sourcing/testing/__init__.py
+++ b/event-sourcing/python/src/event_sourcing/testing/__init__.py
@@ -6,9 +6,10 @@ Each tool addresses a specific testing concern unique to event sourcing.
 
 Tools:
     - scenario(): Given-When-Then command testing
+    - ProcessManagerScenario: Test projection side of ProcessManagers
+    - IdempotencyVerifier: Verify process_pending() is idempotent
     - ReplayTester: Golden replay state verification (TODO)
     - InvariantChecker: Business rule verification (TODO)
-    - ProjectionTester: Read model testing (TODO)
 
 Example:
     >>> from event_sourcing.testing import scenario
@@ -24,6 +25,11 @@ Example:
     ...     ])
 """
 
+from event_sourcing.testing.process_manager_scenario import (
+    IdempotencyResult,
+    IdempotencyVerifier,
+    ProcessManagerScenario,
+)
 from event_sourcing.testing.scenario import (
     AggregateScenario,
     ResultValidator,
@@ -41,4 +47,8 @@ __all__ = [
     "ResultValidator",
     "ScenarioAssertionError",
     "ScenarioExecutionError",
+    # ProcessManager testing
+    "ProcessManagerScenario",
+    "IdempotencyVerifier",
+    "IdempotencyResult",
 ]

--- a/event-sourcing/python/src/event_sourcing/testing/process_manager_scenario.py
+++ b/event-sourcing/python/src/event_sourcing/testing/process_manager_scenario.py
@@ -1,0 +1,190 @@
+"""
+Test utilities for ProcessManager implementations.
+
+Provides tools to test the two sides of a ProcessManager independently:
+
+- ``ProcessManagerScenario``: Test the projection side (handle_event)
+  in isolation, verifying that to-do records are written correctly
+  and that process_pending() is never called during replay.
+
+- ``IdempotencyVerifier``: Test that process_pending() is idempotent
+  by calling it multiple times and verifying effects happen once.
+
+Example::
+
+    from event_sourcing.testing import ProcessManagerScenario
+
+    async def test_dispatch_manager_projection_side():
+        manager = WorkflowDispatchManager(store=mock_store)
+        scenario = ProcessManagerScenario(manager)
+
+        await scenario.given_events([
+            TriggerFiredEvent(trigger_id="t1", execution_id="e1"),
+        ])
+
+        assert scenario.process_pending_call_count == 0
+        assert await mock_store.query(status="pending") == [...]
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from event_sourcing.core.checkpoint import (
+    DispatchContext,
+    ProjectionResult,
+)
+from event_sourcing.stores.memory_checkpoint import MemoryCheckpointStore
+
+if TYPE_CHECKING:
+    from event_sourcing.core.event import DomainEvent, EventEnvelope
+    from event_sourcing.core.process_manager import ProcessManager
+
+
+class ProcessManagerScenario:
+    """Test the projection side of a ProcessManager in isolation.
+
+    Dispatches events through ``handle_event()`` with
+    ``is_catching_up=True`` (replay mode) and tracks whether
+    ``process_pending()`` was called (it should never be during replay).
+    """
+
+    def __init__(self, process_manager: ProcessManager) -> None:
+        self._pm = process_manager
+        self._checkpoint_store = MemoryCheckpointStore()
+        self._process_pending_call_count = 0
+        self._results: list[ProjectionResult] = []
+
+    @property
+    def process_pending_call_count(self) -> int:
+        """Number of times process_pending() was called. Should be 0 after replay."""
+        return self._process_pending_call_count
+
+    @property
+    def results(self) -> list[ProjectionResult]:
+        """Results from each handle_event() call."""
+        return list(self._results)
+
+    async def given_events(
+        self,
+        events: list[EventEnvelope[DomainEvent]],
+    ) -> ProcessManagerScenario:
+        """Replay events through the projection side in catch-up mode.
+
+        All events are dispatched with ``is_catching_up=True``. The
+        scenario verifies that ``process_pending()`` is not called.
+
+        Args:
+            events: Events to replay.
+
+        Returns:
+            Self for chaining.
+        """
+        # Wrap process_pending to track calls
+        original = self._pm.process_pending
+
+        async def _spy_process_pending() -> int:
+            self._process_pending_call_count += 1
+            return await original()
+
+        self._pm.process_pending = _spy_process_pending  # type: ignore[method-assign]
+
+        try:
+            for i, envelope in enumerate(events):
+                global_nonce = envelope.metadata.global_nonce or i
+                context = DispatchContext(
+                    is_catching_up=True,
+                    global_nonce=global_nonce,
+                    live_boundary_nonce=len(events),
+                )
+                result = await self._pm.handle_event(
+                    envelope, self._checkpoint_store, context,
+                )
+                self._results.append(result)
+        finally:
+            self._pm.process_pending = original  # type: ignore[method-assign]
+
+        return self
+
+    async def when_live_event(
+        self,
+        envelope: EventEnvelope[DomainEvent],
+    ) -> ProjectionResult:
+        """Process a single event in live mode.
+
+        Dispatches with ``is_catching_up=False`` and then calls
+        ``process_pending()``, mimicking what the coordinator does
+        for live events.
+
+        Args:
+            envelope: The live event to process.
+
+        Returns:
+            The ProjectionResult from handle_event().
+        """
+        global_nonce = envelope.metadata.global_nonce or 0
+        context = DispatchContext(
+            is_catching_up=False,
+            global_nonce=global_nonce,
+            live_boundary_nonce=global_nonce - 1,
+        )
+        result = await self._pm.handle_event(
+            envelope, self._checkpoint_store, context,
+        )
+        if result == ProjectionResult.SUCCESS:
+            await self._pm.process_pending()
+        return result
+
+
+class IdempotencyVerifier:
+    """Verify that process_pending() is idempotent.
+
+    Calls process_pending() multiple times and checks that the total
+    number of items processed does not increase after the first call
+    (all items should be marked as done after the first pass).
+    """
+
+    def __init__(self, process_manager: ProcessManager) -> None:
+        self._pm = process_manager
+
+    async def verify(self, expected_first_pass: int = 0) -> IdempotencyResult:
+        """Run process_pending() twice and compare results.
+
+        Args:
+            expected_first_pass: Expected number of items on first call.
+
+        Returns:
+            IdempotencyResult with pass counts and whether idempotency holds.
+        """
+        first_count = await self._pm.process_pending()
+        second_count = await self._pm.process_pending()
+
+        return IdempotencyResult(
+            first_pass_count=first_count,
+            second_pass_count=second_count,
+            is_idempotent=second_count == 0,
+            expected_first_pass=expected_first_pass,
+        )
+
+
+class IdempotencyResult:
+    """Result of an idempotency verification."""
+
+    def __init__(
+        self,
+        first_pass_count: int,
+        second_pass_count: int,
+        is_idempotent: bool,
+        expected_first_pass: int,
+    ) -> None:
+        self.first_pass_count = first_pass_count
+        self.second_pass_count = second_pass_count
+        self.is_idempotent = is_idempotent
+        self.expected_first_pass = expected_first_pass
+
+    def __repr__(self) -> str:
+        status = "PASS" if self.is_idempotent else "FAIL"
+        return (
+            f"IdempotencyResult({status}: "
+            f"first={self.first_pass_count}, second={self.second_pass_count})"
+        )

--- a/event-sourcing/python/tests/unit/test_coordinator_gating.py
+++ b/event-sourcing/python/tests/unit/test_coordinator_gating.py
@@ -9,7 +9,6 @@ Verifies that the SubscriptionCoordinator:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
 import pytest
@@ -23,10 +22,6 @@ from event_sourcing.core.event import DomainEvent, EventEnvelope, EventMetadata
 from event_sourcing.core.process_manager import ProcessManager
 from event_sourcing.stores.memory_checkpoint import MemoryCheckpointStore
 from event_sourcing.subscriptions.coordinator import SubscriptionCoordinator
-
-if TYPE_CHECKING:
-    pass
-
 
 # ============================================================================
 # Test Fixtures
@@ -66,8 +61,9 @@ class StubProjection:
     ) -> ProjectionResult:
         self.received_contexts.append(context)
         # Save checkpoint to prevent "already processed" skips
-        from event_sourcing.core.checkpoint import ProjectionCheckpoint
         from datetime import UTC, datetime
+
+        from event_sourcing.core.checkpoint import ProjectionCheckpoint
 
         await checkpoint_store.save_checkpoint(
             ProjectionCheckpoint(
@@ -107,8 +103,9 @@ class StubProcessManager(ProcessManager):
         context: DispatchContext | None = None,
     ) -> ProjectionResult:
         self.handle_event_calls += 1
-        from event_sourcing.core.checkpoint import ProjectionCheckpoint
         from datetime import UTC, datetime
+
+        from event_sourcing.core.checkpoint import ProjectionCheckpoint
 
         await checkpoint_store.save_checkpoint(
             ProjectionCheckpoint(
@@ -305,7 +302,6 @@ class TestProcessManagerGating:
     async def test_process_pending_exception_does_not_crash_coordinator(self) -> None:
         """If process_pending() raises, coordinator should log and continue."""
         pm = StubProcessManager("pm1")
-        original = pm.process_pending
 
         async def _exploding_process_pending() -> int:
             raise RuntimeError("Kaboom!")

--- a/event-sourcing/python/tests/unit/test_coordinator_gating.py
+++ b/event-sourcing/python/tests/unit/test_coordinator_gating.py
@@ -156,8 +156,8 @@ def _make_coordinator(
         checkpoint_store=mock_checkpoint_store,
         projections=projections,  # type: ignore[arg-type]
     )
-    coordinator._live_boundary_nonce = live_boundary_nonce
-    coordinator._is_catching_up = is_catching_up
+    coordinator.live_boundary_nonce = live_boundary_nonce
+    coordinator.is_catching_up = is_catching_up
     return coordinator
 
 
@@ -175,11 +175,11 @@ class TestCatchUpTransition:
         proj = StubProjection("p1")
         coordinator = _make_coordinator([proj], live_boundary_nonce=100, is_catching_up=True)
 
-        await coordinator._dispatch_event(_make_envelope(global_nonce=50))
-        assert coordinator._is_catching_up is True
+        await coordinator.dispatch_event(_make_envelope(global_nonce=50))
+        assert coordinator.is_catching_up is True
 
-        await coordinator._dispatch_event(_make_envelope(global_nonce=100))
-        assert coordinator._is_catching_up is True  # AT boundary, still catching up
+        await coordinator.dispatch_event(_make_envelope(global_nonce=100))
+        assert coordinator.is_catching_up is True  # AT boundary, still catching up
 
     @pytest.mark.asyncio
     async def test_transitions_to_live_past_boundary(self) -> None:
@@ -187,8 +187,8 @@ class TestCatchUpTransition:
         proj = StubProjection("p1")
         coordinator = _make_coordinator([proj], live_boundary_nonce=100, is_catching_up=True)
 
-        await coordinator._dispatch_event(_make_envelope(global_nonce=101))
-        assert coordinator._is_catching_up is False
+        await coordinator.dispatch_event(_make_envelope(global_nonce=101))
+        assert coordinator.is_catching_up is False
 
     @pytest.mark.asyncio
     async def test_transition_is_one_way(self) -> None:
@@ -197,8 +197,8 @@ class TestCatchUpTransition:
         coordinator = _make_coordinator([proj], live_boundary_nonce=100, is_catching_up=False)
 
         # Already live, dispatch event with lower nonce - stays live
-        await coordinator._dispatch_event(_make_envelope(global_nonce=50))
-        assert coordinator._is_catching_up is False
+        await coordinator.dispatch_event(_make_envelope(global_nonce=50))
+        assert coordinator.is_catching_up is False
 
 
 # ============================================================================
@@ -215,7 +215,7 @@ class TestDispatchContextPassing:
         proj = StubProjection("p1")
         coordinator = _make_coordinator([proj], live_boundary_nonce=100, is_catching_up=True)
 
-        await coordinator._dispatch_event(_make_envelope(global_nonce=50))
+        await coordinator.dispatch_event(_make_envelope(global_nonce=50))
 
         assert len(proj.received_contexts) == 1
         ctx = proj.received_contexts[0]
@@ -230,7 +230,7 @@ class TestDispatchContextPassing:
         proj = StubProjection("p1")
         coordinator = _make_coordinator([proj], live_boundary_nonce=100, is_catching_up=False)
 
-        await coordinator._dispatch_event(_make_envelope(global_nonce=101))
+        await coordinator.dispatch_event(_make_envelope(global_nonce=101))
 
         assert len(proj.received_contexts) == 1
         ctx = proj.received_contexts[0]
@@ -253,7 +253,7 @@ class TestProcessManagerGating:
         pm = StubProcessManager("pm1")
         coordinator = _make_coordinator([pm], live_boundary_nonce=100, is_catching_up=True)
 
-        await coordinator._dispatch_event(_make_envelope(global_nonce=50))
+        await coordinator.dispatch_event(_make_envelope(global_nonce=50))
 
         assert pm.handle_event_calls == 1
         assert pm.process_pending_calls == 0  # Key invariant
@@ -264,7 +264,7 @@ class TestProcessManagerGating:
         pm = StubProcessManager("pm1")
         coordinator = _make_coordinator([pm], live_boundary_nonce=100, is_catching_up=False)
 
-        await coordinator._dispatch_event(_make_envelope(global_nonce=101))
+        await coordinator.dispatch_event(_make_envelope(global_nonce=101))
 
         assert pm.handle_event_calls == 1
         assert pm.process_pending_calls == 1  # Should be called
@@ -275,7 +275,7 @@ class TestProcessManagerGating:
         proj = StubProjection("p1")
         coordinator = _make_coordinator([proj], live_boundary_nonce=100, is_catching_up=False)
 
-        await coordinator._dispatch_event(_make_envelope(global_nonce=101))
+        await coordinator.dispatch_event(_make_envelope(global_nonce=101))
 
         # StubProjection doesn't have process_pending_calls attribute
         assert not hasattr(proj, "process_pending_calls")
@@ -288,13 +288,13 @@ class TestProcessManagerGating:
 
         # Catch-up events (1-5): no process_pending
         for nonce in range(1, 6):
-            await coordinator._dispatch_event(_make_envelope(global_nonce=nonce))
+            await coordinator.dispatch_event(_make_envelope(global_nonce=nonce))
         assert pm.handle_event_calls == 5
         assert pm.process_pending_calls == 0
 
         # Live events (6-8): process_pending called each time
         for nonce in range(6, 9):
-            await coordinator._dispatch_event(_make_envelope(global_nonce=nonce))
+            await coordinator.dispatch_event(_make_envelope(global_nonce=nonce))
         assert pm.handle_event_calls == 8
         assert pm.process_pending_calls == 3
 
@@ -311,7 +311,7 @@ class TestProcessManagerGating:
         coordinator = _make_coordinator([pm], live_boundary_nonce=0, is_catching_up=False)
 
         # Should not raise - coordinator catches and logs the exception
-        await coordinator._dispatch_event(_make_envelope(global_nonce=1))
+        await coordinator.dispatch_event(_make_envelope(global_nonce=1))
 
         # handle_event was still called
         assert pm.handle_event_calls == 1

--- a/event-sourcing/python/tests/unit/test_coordinator_gating.py
+++ b/event-sourcing/python/tests/unit/test_coordinator_gating.py
@@ -1,0 +1,321 @@
+"""Tests for coordinator catch-up tracking and ProcessManager gating.
+
+Verifies that the SubscriptionCoordinator:
+1. Tracks catch-up/live transition using global_nonce boundary
+2. Passes DispatchContext to handle_event()
+3. Gates process_pending() - never called during catch-up
+4. Calls process_pending() only for live events on ProcessManager instances
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+
+from event_sourcing.core.checkpoint import (
+    DispatchContext,
+    ProjectionCheckpointStore,
+    ProjectionResult,
+)
+from event_sourcing.core.event import DomainEvent, EventEnvelope, EventMetadata
+from event_sourcing.core.process_manager import ProcessManager
+from event_sourcing.stores.memory_checkpoint import MemoryCheckpointStore
+from event_sourcing.subscriptions.coordinator import SubscriptionCoordinator
+
+if TYPE_CHECKING:
+    pass
+
+
+# ============================================================================
+# Test Fixtures
+# ============================================================================
+
+
+class TestEvent(DomainEvent):
+    """Simple test event."""
+
+    event_type = "TestEvent"
+    value: str
+
+
+class StubProjection:
+    """Minimal stub that acts like CheckpointedProjection without subclassing."""
+
+    SIDE_EFFECTS_ALLOWED = False
+
+    def __init__(self, name: str = "stub") -> None:
+        self._name = name
+        self.received_contexts: list[DispatchContext | None] = []
+
+    def get_name(self) -> str:
+        return self._name
+
+    def get_version(self) -> int:
+        return 1
+
+    def get_subscribed_event_types(self) -> set[str] | None:
+        return None  # Subscribe to all
+
+    async def handle_event(
+        self,
+        envelope: EventEnvelope[DomainEvent],
+        checkpoint_store: ProjectionCheckpointStore,
+        context: DispatchContext | None = None,
+    ) -> ProjectionResult:
+        self.received_contexts.append(context)
+        # Save checkpoint to prevent "already processed" skips
+        from event_sourcing.core.checkpoint import ProjectionCheckpoint
+        from datetime import UTC, datetime
+
+        await checkpoint_store.save_checkpoint(
+            ProjectionCheckpoint(
+                projection_name=self._name,
+                global_position=envelope.metadata.global_nonce or 0,
+                updated_at=datetime.now(UTC),
+                version=self.get_version(),
+            )
+        )
+        return ProjectionResult.SUCCESS
+
+    async def clear_all_data(self) -> None:
+        pass
+
+
+class StubProcessManager(ProcessManager):
+    """Concrete ProcessManager for coordinator gating tests."""
+
+    def __init__(self, name: str = "stub_pm") -> None:
+        self._name = name
+        self.process_pending_calls: int = 0
+        self.handle_event_calls: int = 0
+
+    def get_name(self) -> str:
+        return self._name
+
+    def get_version(self) -> int:
+        return 1
+
+    def get_subscribed_event_types(self) -> set[str] | None:
+        return None
+
+    async def handle_event(
+        self,
+        envelope: EventEnvelope[DomainEvent],
+        checkpoint_store: ProjectionCheckpointStore,
+        context: DispatchContext | None = None,
+    ) -> ProjectionResult:
+        self.handle_event_calls += 1
+        from event_sourcing.core.checkpoint import ProjectionCheckpoint
+        from datetime import UTC, datetime
+
+        await checkpoint_store.save_checkpoint(
+            ProjectionCheckpoint(
+                projection_name=self._name,
+                global_position=envelope.metadata.global_nonce or 0,
+                updated_at=datetime.now(UTC),
+                version=self.get_version(),
+            )
+        )
+        return ProjectionResult.SUCCESS
+
+    async def process_pending(self) -> int:
+        self.process_pending_calls += 1
+        return 1
+
+    def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+        return str(todo_item.get("id", ""))
+
+    async def clear_all_data(self) -> None:
+        pass
+
+
+def _make_envelope(global_nonce: int) -> EventEnvelope[DomainEvent]:
+    """Create a test EventEnvelope."""
+    return EventEnvelope(
+        event=TestEvent(value="test"),
+        metadata=EventMetadata(
+            aggregate_nonce=1,
+            aggregate_id="agg-1",
+            aggregate_type="TestAggregate",
+            global_nonce=global_nonce,
+            event_type="TestEvent",
+        ),
+    )
+
+
+def _make_coordinator(
+    projections: list[object],
+    live_boundary_nonce: int = 100,
+    is_catching_up: bool = True,
+) -> SubscriptionCoordinator:
+    """Create a coordinator with pre-set catch-up state."""
+    mock_store = AsyncMock()
+    mock_checkpoint_store = MemoryCheckpointStore()
+
+    coordinator = SubscriptionCoordinator(
+        event_store=mock_store,
+        checkpoint_store=mock_checkpoint_store,
+        projections=projections,  # type: ignore[arg-type]
+    )
+    coordinator._live_boundary_nonce = live_boundary_nonce
+    coordinator._is_catching_up = is_catching_up
+    return coordinator
+
+
+# ============================================================================
+# Catch-Up Transition Tests
+# ============================================================================
+
+
+class TestCatchUpTransition:
+    """Tests for catch-up to live transition logic."""
+
+    @pytest.mark.asyncio
+    async def test_stays_catching_up_below_boundary(self) -> None:
+        """Should remain in catch-up mode for events at or below boundary."""
+        proj = StubProjection("p1")
+        coordinator = _make_coordinator([proj], live_boundary_nonce=100, is_catching_up=True)
+
+        await coordinator._dispatch_event(_make_envelope(global_nonce=50))
+        assert coordinator._is_catching_up is True
+
+        await coordinator._dispatch_event(_make_envelope(global_nonce=100))
+        assert coordinator._is_catching_up is True  # AT boundary, still catching up
+
+    @pytest.mark.asyncio
+    async def test_transitions_to_live_past_boundary(self) -> None:
+        """Should transition to live when global_nonce > live_boundary_nonce."""
+        proj = StubProjection("p1")
+        coordinator = _make_coordinator([proj], live_boundary_nonce=100, is_catching_up=True)
+
+        await coordinator._dispatch_event(_make_envelope(global_nonce=101))
+        assert coordinator._is_catching_up is False
+
+    @pytest.mark.asyncio
+    async def test_transition_is_one_way(self) -> None:
+        """Once live, should stay live even if global_nonce appears lower."""
+        proj = StubProjection("p1")
+        coordinator = _make_coordinator([proj], live_boundary_nonce=100, is_catching_up=False)
+
+        # Already live, dispatch event with lower nonce - stays live
+        await coordinator._dispatch_event(_make_envelope(global_nonce=50))
+        assert coordinator._is_catching_up is False
+
+
+# ============================================================================
+# DispatchContext Passing Tests
+# ============================================================================
+
+
+class TestDispatchContextPassing:
+    """Tests that coordinator passes DispatchContext to projections."""
+
+    @pytest.mark.asyncio
+    async def test_context_passed_during_catchup(self) -> None:
+        """Should pass DispatchContext with is_catching_up=True during catch-up."""
+        proj = StubProjection("p1")
+        coordinator = _make_coordinator([proj], live_boundary_nonce=100, is_catching_up=True)
+
+        await coordinator._dispatch_event(_make_envelope(global_nonce=50))
+
+        assert len(proj.received_contexts) == 1
+        ctx = proj.received_contexts[0]
+        assert ctx is not None
+        assert ctx.is_catching_up is True
+        assert ctx.global_nonce == 50
+        assert ctx.live_boundary_nonce == 100
+
+    @pytest.mark.asyncio
+    async def test_context_passed_during_live(self) -> None:
+        """Should pass DispatchContext with is_catching_up=False for live events."""
+        proj = StubProjection("p1")
+        coordinator = _make_coordinator([proj], live_boundary_nonce=100, is_catching_up=False)
+
+        await coordinator._dispatch_event(_make_envelope(global_nonce=101))
+
+        assert len(proj.received_contexts) == 1
+        ctx = proj.received_contexts[0]
+        assert ctx is not None
+        assert ctx.is_catching_up is False
+        assert ctx.global_nonce == 101
+
+
+# ============================================================================
+# ProcessManager Gating Tests
+# ============================================================================
+
+
+class TestProcessManagerGating:
+    """Tests that coordinator gates process_pending() on live mode."""
+
+    @pytest.mark.asyncio
+    async def test_no_process_pending_during_catchup(self) -> None:
+        """process_pending() must NOT be called during catch-up replay."""
+        pm = StubProcessManager("pm1")
+        coordinator = _make_coordinator([pm], live_boundary_nonce=100, is_catching_up=True)
+
+        await coordinator._dispatch_event(_make_envelope(global_nonce=50))
+
+        assert pm.handle_event_calls == 1
+        assert pm.process_pending_calls == 0  # Key invariant
+
+    @pytest.mark.asyncio
+    async def test_process_pending_called_for_live_events(self) -> None:
+        """process_pending() should be called for live events on ProcessManager."""
+        pm = StubProcessManager("pm1")
+        coordinator = _make_coordinator([pm], live_boundary_nonce=100, is_catching_up=False)
+
+        await coordinator._dispatch_event(_make_envelope(global_nonce=101))
+
+        assert pm.handle_event_calls == 1
+        assert pm.process_pending_calls == 1  # Should be called
+
+    @pytest.mark.asyncio
+    async def test_no_process_pending_on_regular_projection(self) -> None:
+        """Regular projections should not have process_pending() called."""
+        proj = StubProjection("p1")
+        coordinator = _make_coordinator([proj], live_boundary_nonce=100, is_catching_up=False)
+
+        await coordinator._dispatch_event(_make_envelope(global_nonce=101))
+
+        # StubProjection doesn't have process_pending_calls attribute
+        assert not hasattr(proj, "process_pending_calls")
+
+    @pytest.mark.asyncio
+    async def test_replay_then_live_sequence(self) -> None:
+        """Full sequence: catch-up events then live. process_pending only on live."""
+        pm = StubProcessManager("pm1")
+        coordinator = _make_coordinator([pm], live_boundary_nonce=5, is_catching_up=True)
+
+        # Catch-up events (1-5): no process_pending
+        for nonce in range(1, 6):
+            await coordinator._dispatch_event(_make_envelope(global_nonce=nonce))
+        assert pm.handle_event_calls == 5
+        assert pm.process_pending_calls == 0
+
+        # Live events (6-8): process_pending called each time
+        for nonce in range(6, 9):
+            await coordinator._dispatch_event(_make_envelope(global_nonce=nonce))
+        assert pm.handle_event_calls == 8
+        assert pm.process_pending_calls == 3
+
+    @pytest.mark.asyncio
+    async def test_process_pending_exception_does_not_crash_coordinator(self) -> None:
+        """If process_pending() raises, coordinator should log and continue."""
+        pm = StubProcessManager("pm1")
+        original = pm.process_pending
+
+        async def _exploding_process_pending() -> int:
+            raise RuntimeError("Kaboom!")
+
+        pm.process_pending = _exploding_process_pending  # type: ignore[method-assign]  # noqa: E501
+
+        coordinator = _make_coordinator([pm], live_boundary_nonce=0, is_catching_up=False)
+
+        # Should not raise - coordinator catches and logs the exception
+        await coordinator._dispatch_event(_make_envelope(global_nonce=1))
+
+        # handle_event was still called
+        assert pm.handle_event_calls == 1

--- a/event-sourcing/python/tests/unit/test_coordinator_gating.py
+++ b/event-sourcing/python/tests/unit/test_coordinator_gating.py
@@ -121,7 +121,7 @@ class StubProcessManager(ProcessManager):
         self.process_pending_calls += 1
         return 1
 
-    def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+    def get_idempotency_key(self, todo_item: dict[str, str | int | float | bool | None]) -> str:
         return str(todo_item.get("id", ""))
 
     async def clear_all_data(self) -> None:

--- a/event-sourcing/python/tests/unit/test_dispatch_context.py
+++ b/event-sourcing/python/tests/unit/test_dispatch_context.py
@@ -1,0 +1,147 @@
+"""Tests for DispatchContext and SIDE_EFFECTS_ALLOWED marker."""
+
+import pytest
+
+from event_sourcing.core.checkpoint import (
+    CheckpointedProjection,
+    DispatchContext,
+    ProjectionCheckpointStore,
+    ProjectionResult,
+)
+from event_sourcing.core.event import DomainEvent, EventEnvelope
+from event_sourcing.core.process_manager import ProcessManager
+
+
+# ============================================================================
+# DispatchContext Tests
+# ============================================================================
+
+
+class TestDispatchContext:
+    """Tests for DispatchContext frozen dataclass."""
+
+    def test_create_catching_up(self) -> None:
+        """Should create context in catch-up mode."""
+        ctx = DispatchContext(
+            is_catching_up=True,
+            global_nonce=5,
+            live_boundary_nonce=100,
+        )
+        assert ctx.is_catching_up is True
+        assert ctx.global_nonce == 5
+        assert ctx.live_boundary_nonce == 100
+
+    def test_create_live(self) -> None:
+        """Should create context in live mode."""
+        ctx = DispatchContext(
+            is_catching_up=False,
+            global_nonce=101,
+            live_boundary_nonce=100,
+        )
+        assert ctx.is_catching_up is False
+        assert ctx.global_nonce == 101
+        assert ctx.live_boundary_nonce == 100
+
+    def test_is_live_property(self) -> None:
+        """is_live should be the inverse of is_catching_up."""
+        catching_up = DispatchContext(
+            is_catching_up=True, global_nonce=1, live_boundary_nonce=100,
+        )
+        live = DispatchContext(
+            is_catching_up=False, global_nonce=101, live_boundary_nonce=100,
+        )
+        assert catching_up.is_live is False
+        assert live.is_live is True
+
+    def test_frozen(self) -> None:
+        """DispatchContext should be immutable."""
+        ctx = DispatchContext(
+            is_catching_up=True, global_nonce=1, live_boundary_nonce=100,
+        )
+        with pytest.raises(AttributeError):
+            ctx.is_catching_up = False  # type: ignore[misc]
+
+    def test_boundary_semantics(self) -> None:
+        """Events at boundary nonce are historical, above are live.
+
+        The transition uses > (strictly greater than). Events at the boundary
+        were already in the store when we subscribed.
+        """
+        at_boundary = DispatchContext(
+            is_catching_up=True, global_nonce=100, live_boundary_nonce=100,
+        )
+        # At the boundary: still catching up
+        assert at_boundary.is_catching_up is True
+
+        past_boundary = DispatchContext(
+            is_catching_up=False, global_nonce=101, live_boundary_nonce=100,
+        )
+        # Past the boundary: live
+        assert past_boundary.is_live is True
+
+
+# ============================================================================
+# SIDE_EFFECTS_ALLOWED Tests
+# ============================================================================
+
+
+class TestSideEffectsAllowed:
+    """Tests for SIDE_EFFECTS_ALLOWED ClassVar marker."""
+
+    def test_projection_disallows_side_effects(self) -> None:
+        """CheckpointedProjection should have SIDE_EFFECTS_ALLOWED=False."""
+        assert CheckpointedProjection.SIDE_EFFECTS_ALLOWED is False
+
+    def test_process_manager_allows_side_effects(self) -> None:
+        """ProcessManager should have SIDE_EFFECTS_ALLOWED=True."""
+        assert ProcessManager.SIDE_EFFECTS_ALLOWED is True
+
+    def test_projection_subclass_inherits_false(self) -> None:
+        """A projection subclass should inherit SIDE_EFFECTS_ALLOWED=False."""
+
+        class MyProjection(CheckpointedProjection):
+            def get_name(self) -> str:
+                return "my_projection"
+
+            def get_version(self) -> int:
+                return 1
+
+            def get_subscribed_event_types(self) -> set[str]:
+                return {"TestEvent"}
+
+            async def handle_event(
+                self, envelope: EventEnvelope[DomainEvent],
+                checkpoint_store: ProjectionCheckpointStore,
+                context: DispatchContext | None = None,
+            ) -> ProjectionResult:
+                return ProjectionResult.SUCCESS
+
+        assert MyProjection.SIDE_EFFECTS_ALLOWED is False
+
+    def test_process_manager_subclass_inherits_true(self) -> None:
+        """A ProcessManager subclass should inherit SIDE_EFFECTS_ALLOWED=True."""
+
+        class MyManager(ProcessManager):
+            def get_name(self) -> str:
+                return "my_manager"
+
+            def get_version(self) -> int:
+                return 1
+
+            def get_subscribed_event_types(self) -> set[str]:
+                return {"TestEvent"}
+
+            async def handle_event(
+                self, envelope: EventEnvelope[DomainEvent],
+                checkpoint_store: ProjectionCheckpointStore,
+                context: DispatchContext | None = None,
+            ) -> ProjectionResult:
+                return ProjectionResult.SUCCESS
+
+            async def process_pending(self) -> int:
+                return 0
+
+            def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+                return str(todo_item.get("id", ""))
+
+        assert MyManager.SIDE_EFFECTS_ALLOWED is True

--- a/event-sourcing/python/tests/unit/test_dispatch_context.py
+++ b/event-sourcing/python/tests/unit/test_dispatch_context.py
@@ -11,7 +11,6 @@ from event_sourcing.core.checkpoint import (
 from event_sourcing.core.event import DomainEvent, EventEnvelope
 from event_sourcing.core.process_manager import ProcessManager
 
-
 # ============================================================================
 # DispatchContext Tests
 # ============================================================================

--- a/event-sourcing/python/tests/unit/test_dispatch_context.py
+++ b/event-sourcing/python/tests/unit/test_dispatch_context.py
@@ -140,7 +140,7 @@ class TestSideEffectsAllowed:
             async def process_pending(self) -> int:
                 return 0
 
-            def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+            def get_idempotency_key(self, todo_item: dict[str, str | int | float | bool | None]) -> str:
                 return str(todo_item.get("id", ""))
 
         assert MyManager.SIDE_EFFECTS_ALLOWED is True

--- a/event-sourcing/python/tests/unit/test_fitness.py
+++ b/event-sourcing/python/tests/unit/test_fitness.py
@@ -8,8 +8,8 @@ Tests cover:
 
 from __future__ import annotations
 
-from pathlib import Path
 from textwrap import dedent
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -27,6 +27,8 @@ from event_sourcing.fitness.projection_purity import (
 )
 from event_sourcing.fitness.violations import Violation
 
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # ============================================================================
 # Violation Tests

--- a/event-sourcing/python/tests/unit/test_fitness.py
+++ b/event-sourcing/python/tests/unit/test_fitness.py
@@ -1,0 +1,479 @@
+"""Tests for the built-in fitness module.
+
+Tests cover:
+1. Projection purity check (whitelist-based import analysis)
+2. ProcessManager structure check
+3. Violation dataclass
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from event_sourcing.core.checkpoint import (
+    DispatchContext,
+    ProjectionCheckpointStore,
+    ProjectionResult,
+)
+from event_sourcing.core.event import DomainEvent, EventEnvelope
+from event_sourcing.core.process_manager import ProcessManager
+from event_sourcing.fitness.process_manager_check import check_process_manager
+from event_sourcing.fitness.projection_purity import (
+    PROJECTION_ALLOWED_PREFIXES,
+    check_projection_purity,
+)
+from event_sourcing.fitness.violations import Violation
+
+
+# ============================================================================
+# Violation Tests
+# ============================================================================
+
+
+class TestViolation:
+    """Tests for the Violation dataclass."""
+
+    def test_create_violation(self) -> None:
+        """Should create a violation with all fields."""
+        v = Violation(
+            file_path="projection.py",
+            line_number=10,
+            rule="projection-purity",
+            message="Bad import",
+        )
+        assert v.file_path == "projection.py"
+        assert v.line_number == 10
+        assert v.rule == "projection-purity"
+        assert v.message == "Bad import"
+
+    def test_violation_is_frozen(self) -> None:
+        """Violation should be immutable."""
+        v = Violation(
+            file_path="test.py", line_number=1, rule="test", message="test",
+        )
+        with pytest.raises(AttributeError):
+            v.message = "changed"  # type: ignore[misc]
+
+
+# ============================================================================
+# Projection Purity Tests
+# ============================================================================
+
+
+class TestProjectionPurity:
+    """Tests for whitelist-based projection purity check."""
+
+    def test_pure_projection_passes(self, tmp_path: Path) -> None:
+        """A projection with only allowed imports should have no violations."""
+        source = dedent("""\
+            from __future__ import annotations
+            import logging
+            from typing import Optional
+            from datetime import datetime
+            from event_sourcing.core.checkpoint import ProjectionResult
+
+            class MyProjection:
+                pass
+        """)
+        f = tmp_path / "pure_projection.py"
+        f.write_text(source)
+
+        violations = check_projection_purity(f)
+        assert violations == []
+
+    def test_httpx_import_flagged(self, tmp_path: Path) -> None:
+        """Importing httpx should be flagged as a purity violation."""
+        source = dedent("""\
+            import httpx
+
+            class BadProjection:
+                pass
+        """)
+        f = tmp_path / "bad_projection.py"
+        f.write_text(source)
+
+        violations = check_projection_purity(f)
+        assert len(violations) == 1
+        assert "httpx" in violations[0].message
+        assert violations[0].rule == "projection-purity"
+
+    def test_from_import_flagged(self, tmp_path: Path) -> None:
+        """from X import Y where X is not whitelisted should be flagged."""
+        source = dedent("""\
+            from requests import get
+
+            class BadProjection:
+                pass
+        """)
+        f = tmp_path / "bad_projection.py"
+        f.write_text(source)
+
+        violations = check_projection_purity(f)
+        assert len(violations) == 1
+        assert "requests" in violations[0].message
+
+    def test_type_checking_import_allowed(self, tmp_path: Path) -> None:
+        """Imports inside TYPE_CHECKING blocks should always be allowed."""
+        source = dedent("""\
+            from __future__ import annotations
+            from typing import TYPE_CHECKING
+
+            if TYPE_CHECKING:
+                import httpx
+                from docker import DockerClient
+
+            class PureProjection:
+                pass
+        """)
+        f = tmp_path / "pure_projection.py"
+        f.write_text(source)
+
+        violations = check_projection_purity(f)
+        assert violations == []
+
+    def test_multiple_violations(self, tmp_path: Path) -> None:
+        """Should flag all non-whitelisted imports."""
+        source = dedent("""\
+            import httpx
+            import subprocess
+            from boto3 import client
+
+            class ReallyBadProjection:
+                pass
+        """)
+        f = tmp_path / "multi_bad.py"
+        f.write_text(source)
+
+        violations = check_projection_purity(f)
+        assert len(violations) == 3
+
+    def test_project_specific_allowed_prefixes(self, tmp_path: Path) -> None:
+        """Project-specific prefixes should be allowed when provided."""
+        source = dedent("""\
+            from syn_domain.contexts.github.events import TriggerFiredEvent
+            from syn_shared.settings import Settings
+
+            class SynProjection:
+                pass
+        """)
+        f = tmp_path / "syn_projection.py"
+        f.write_text(source)
+
+        # Without project-specific: violations
+        violations = check_projection_purity(f)
+        assert len(violations) == 2
+
+        # With project-specific: no violations
+        violations = check_projection_purity(
+            f, allowed_prefixes={"syn_domain", "syn_shared"},
+        )
+        assert violations == []
+
+    def test_event_sourcing_submodules_allowed(self, tmp_path: Path) -> None:
+        """All event_sourcing.* imports should be allowed."""
+        source = dedent("""\
+            from event_sourcing.core.checkpoint import ProjectionResult
+            from event_sourcing.core.event import DomainEvent
+            from event_sourcing.stores.memory_checkpoint import MemoryCheckpointStore
+        """)
+        f = tmp_path / "es_imports.py"
+        f.write_text(source)
+
+        violations = check_projection_purity(f)
+        assert violations == []
+
+    def test_syntax_error_returns_violation(self, tmp_path: Path) -> None:
+        """Files with syntax errors should produce a single violation."""
+        f = tmp_path / "broken.py"
+        f.write_text("def broken(:\n")
+
+        violations = check_projection_purity(f)
+        assert len(violations) == 1
+        assert "SyntaxError" in violations[0].message
+
+    def test_default_prefixes_include_stdlib(self) -> None:
+        """Default allowed prefixes should include common stdlib modules."""
+        expected = {"typing", "logging", "datetime", "uuid", "enum", "dataclasses", "abc"}
+        for module in expected:
+            assert module in PROJECTION_ALLOWED_PREFIXES, f"{module} not in default allowed"
+
+    def test_default_prefixes_include_esp(self) -> None:
+        """Default allowed prefixes should include event_sourcing."""
+        assert "event_sourcing" in PROJECTION_ALLOWED_PREFIXES
+
+
+# ============================================================================
+# ProcessManager Structure Check Tests
+# ============================================================================
+
+
+class TestProcessManagerCheck:
+    """Tests for ProcessManager structure validation."""
+
+    def test_valid_process_manager(self) -> None:
+        """A complete ProcessManager should have no violations."""
+
+        class ValidPM(ProcessManager):
+            def get_name(self) -> str:
+                return "valid"
+
+            def get_version(self) -> int:
+                return 1
+
+            def get_subscribed_event_types(self) -> set[str]:
+                return set()
+
+            async def handle_event(
+                self, envelope: EventEnvelope[DomainEvent],
+                checkpoint_store: ProjectionCheckpointStore,
+                context: DispatchContext | None = None,
+            ) -> ProjectionResult:
+                return ProjectionResult.SUCCESS
+
+            async def process_pending(self) -> int:
+                return 0
+
+            def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+                return ""
+
+        violations = check_process_manager(ValidPM)
+        assert violations == []
+
+    def test_side_effects_overridden_to_false(self) -> None:
+        """Should flag ProcessManager with SIDE_EFFECTS_ALLOWED=False."""
+
+        class BadPM(ProcessManager):
+            SIDE_EFFECTS_ALLOWED = False  # type: ignore[assignment]
+
+            def get_name(self) -> str:
+                return "bad"
+
+            def get_version(self) -> int:
+                return 1
+
+            def get_subscribed_event_types(self) -> set[str]:
+                return set()
+
+            async def handle_event(
+                self, envelope: EventEnvelope[DomainEvent],
+                checkpoint_store: ProjectionCheckpointStore,
+                context: DispatchContext | None = None,
+            ) -> ProjectionResult:
+                return ProjectionResult.SUCCESS
+
+            async def process_pending(self) -> int:
+                return 0
+
+            def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+                return ""
+
+        violations = check_process_manager(BadPM)
+        assert len(violations) == 1
+        assert "SIDE_EFFECTS_ALLOWED" in violations[0].message
+
+
+# ============================================================================
+# Test Kit Tests
+# ============================================================================
+
+
+class TestProcessManagerScenario:
+    """Tests for the ProcessManagerScenario test utility."""
+
+    @pytest.mark.asyncio
+    async def test_given_events_does_not_call_process_pending(self) -> None:
+        """given_events() should dispatch in catch-up mode - no process_pending."""
+        from event_sourcing.testing import ProcessManagerScenario
+
+        class TestPM(ProcessManager):
+            def __init__(self) -> None:
+                self.events_received: list[str] = []
+
+            def get_name(self) -> str:
+                return "test_pm"
+
+            def get_version(self) -> int:
+                return 1
+
+            def get_subscribed_event_types(self) -> set[str]:
+                return {"TestEvent"}
+
+            async def handle_event(
+                self, envelope: EventEnvelope[DomainEvent],
+                checkpoint_store: ProjectionCheckpointStore,
+                context: DispatchContext | None = None,
+            ) -> ProjectionResult:
+                self.events_received.append(envelope.metadata.event_type or "")
+                return ProjectionResult.SUCCESS
+
+            async def process_pending(self) -> int:
+                return 0
+
+            def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+                return ""
+
+        from event_sourcing.core.event import EventMetadata
+
+        pm = TestPM()
+        scenario = ProcessManagerScenario(pm)
+
+        envelopes = []
+        for i in range(3):
+
+            class SimpleEvent(DomainEvent):
+                event_type = "TestEvent"
+
+            envelopes.append(EventEnvelope(
+                event=SimpleEvent(),
+                metadata=EventMetadata(
+                    aggregate_nonce=1,
+                    aggregate_id=f"agg-{i}",
+                    aggregate_type="Test",
+                    global_nonce=i + 1,
+                    event_type="TestEvent",
+                ),
+            ))
+
+        await scenario.given_events(envelopes)
+
+        assert len(pm.events_received) == 3
+        assert scenario.process_pending_call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_when_live_event_calls_process_pending(self) -> None:
+        """when_live_event() should call process_pending() after handle_event."""
+        from event_sourcing.testing import ProcessManagerScenario
+
+        class TestPM(ProcessManager):
+            def __init__(self) -> None:
+                self.pending_called = False
+
+            def get_name(self) -> str:
+                return "test_pm"
+
+            def get_version(self) -> int:
+                return 1
+
+            def get_subscribed_event_types(self) -> set[str]:
+                return {"TestEvent"}
+
+            async def handle_event(
+                self, envelope: EventEnvelope[DomainEvent],
+                checkpoint_store: ProjectionCheckpointStore,
+                context: DispatchContext | None = None,
+            ) -> ProjectionResult:
+                return ProjectionResult.SUCCESS
+
+            async def process_pending(self) -> int:
+                self.pending_called = True
+                return 1
+
+            def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+                return ""
+
+        from event_sourcing.core.event import EventMetadata
+
+        class SimpleEvent(DomainEvent):
+            event_type = "TestEvent"
+
+        pm = TestPM()
+        scenario = ProcessManagerScenario(pm)
+
+        envelope = EventEnvelope(
+            event=SimpleEvent(),
+            metadata=EventMetadata(
+                aggregate_nonce=1,
+                aggregate_id="agg-1",
+                aggregate_type="Test",
+                global_nonce=10,
+                event_type="TestEvent",
+            ),
+        )
+
+        result = await scenario.when_live_event(envelope)
+        assert result == ProjectionResult.SUCCESS
+        assert pm.pending_called is True
+
+
+class TestIdempotencyVerifier:
+    """Tests for the IdempotencyVerifier test utility."""
+
+    @pytest.mark.asyncio
+    async def test_idempotent_process_manager(self) -> None:
+        """Idempotent process_pending should return is_idempotent=True."""
+        from event_sourcing.testing import IdempotencyVerifier
+
+        class IdempotentPM(ProcessManager):
+            def __init__(self) -> None:
+                self._first_call = True
+
+            def get_name(self) -> str:
+                return "idem"
+
+            def get_version(self) -> int:
+                return 1
+
+            def get_subscribed_event_types(self) -> set[str]:
+                return set()
+
+            async def handle_event(
+                self, envelope: EventEnvelope[DomainEvent],
+                checkpoint_store: ProjectionCheckpointStore,
+                context: DispatchContext | None = None,
+            ) -> ProjectionResult:
+                return ProjectionResult.SUCCESS
+
+            async def process_pending(self) -> int:
+                if self._first_call:
+                    self._first_call = False
+                    return 3
+                return 0  # Idempotent: second call processes nothing
+
+            def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+                return ""
+
+        pm = IdempotentPM()
+        verifier = IdempotencyVerifier(pm)
+        result = await verifier.verify(expected_first_pass=3)
+
+        assert result.first_pass_count == 3
+        assert result.second_pass_count == 0
+        assert result.is_idempotent is True
+
+    @pytest.mark.asyncio
+    async def test_non_idempotent_detected(self) -> None:
+        """Non-idempotent process_pending should return is_idempotent=False."""
+        from event_sourcing.testing import IdempotencyVerifier
+
+        class NonIdempotentPM(ProcessManager):
+            def get_name(self) -> str:
+                return "non_idem"
+
+            def get_version(self) -> int:
+                return 1
+
+            def get_subscribed_event_types(self) -> set[str]:
+                return set()
+
+            async def handle_event(
+                self, envelope: EventEnvelope[DomainEvent],
+                checkpoint_store: ProjectionCheckpointStore,
+                context: DispatchContext | None = None,
+            ) -> ProjectionResult:
+                return ProjectionResult.SUCCESS
+
+            async def process_pending(self) -> int:
+                return 2  # Always processes 2, not idempotent
+
+            def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+                return ""
+
+        pm = NonIdempotentPM()
+        verifier = IdempotencyVerifier(pm)
+        result = await verifier.verify()
+
+        assert result.second_pass_count == 2
+        assert result.is_idempotent is False

--- a/event-sourcing/python/tests/unit/test_fitness.py
+++ b/event-sourcing/python/tests/unit/test_fitness.py
@@ -238,7 +238,7 @@ class TestProcessManagerCheck:
             async def process_pending(self) -> int:
                 return 0
 
-            def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+            def get_idempotency_key(self, todo_item: dict[str, str | int | float | bool | None]) -> str:
                 return ""
 
         violations = check_process_manager(ValidPM)
@@ -269,7 +269,7 @@ class TestProcessManagerCheck:
             async def process_pending(self) -> int:
                 return 0
 
-            def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+            def get_idempotency_key(self, todo_item: dict[str, str | int | float | bool | None]) -> str:
                 return ""
 
         violations = check_process_manager(BadPM)
@@ -314,7 +314,7 @@ class TestProcessManagerScenario:
             async def process_pending(self) -> int:
                 return 0
 
-            def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+            def get_idempotency_key(self, todo_item: dict[str, str | int | float | bool | None]) -> str:
                 return ""
 
         from event_sourcing.core.event import EventMetadata
@@ -373,7 +373,7 @@ class TestProcessManagerScenario:
                 self.pending_called = True
                 return 1
 
-            def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+            def get_idempotency_key(self, todo_item: dict[str, str | int | float | bool | None]) -> str:
                 return ""
 
         from event_sourcing.core.event import EventMetadata
@@ -434,7 +434,7 @@ class TestIdempotencyVerifier:
                     return 3
                 return 0  # Idempotent: second call processes nothing
 
-            def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+            def get_idempotency_key(self, todo_item: dict[str, str | int | float | bool | None]) -> str:
                 return ""
 
         pm = IdempotentPM()
@@ -470,7 +470,7 @@ class TestIdempotencyVerifier:
             async def process_pending(self) -> int:
                 return 2  # Always processes 2, not idempotent
 
-            def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+            def get_idempotency_key(self, todo_item: dict[str, str | int | float | bool | None]) -> str:
                 return ""
 
         pm = NonIdempotentPM()

--- a/event-sourcing/python/tests/unit/test_process_manager.py
+++ b/event-sourcing/python/tests/unit/test_process_manager.py
@@ -13,7 +13,6 @@ from event_sourcing.core.checkpoint import (
 from event_sourcing.core.event import DomainEvent, EventEnvelope, EventMetadata
 from event_sourcing.core.process_manager import ProcessManager
 
-
 # ============================================================================
 # Test Events
 # ============================================================================

--- a/event-sourcing/python/tests/unit/test_process_manager.py
+++ b/event-sourcing/python/tests/unit/test_process_manager.py
@@ -38,8 +38,8 @@ class TodoProcessManager(ProcessManager):
     """
 
     def __init__(self) -> None:
-        self.pending_items: list[dict[str, object]] = []
-        self.done_items: list[dict[str, object]] = []
+        self.pending_items: list[dict[str, str | int | float | bool | None]] = []
+        self.done_items: list[dict[str, str | int | float | bool | None]] = []
         self.process_pending_calls: int = 0
         self.handle_event_calls: int = 0
 
@@ -75,7 +75,7 @@ class TodoProcessManager(ProcessManager):
         self.pending_items = [i for i in self.pending_items if i["status"] == "pending"]
         return processed
 
-    def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+    def get_idempotency_key(self, todo_item: dict[str, str | int | float | bool | None]) -> str:
         return str(todo_item["task_id"])
 
 

--- a/event-sourcing/python/tests/unit/test_process_manager.py
+++ b/event-sourcing/python/tests/unit/test_process_manager.py
@@ -1,0 +1,245 @@
+"""Tests for ProcessManager base class and coordinator gating."""
+
+from __future__ import annotations
+
+import pytest
+
+from event_sourcing.core.checkpoint import (
+    CheckpointedProjection,
+    DispatchContext,
+    ProjectionCheckpointStore,
+    ProjectionResult,
+)
+from event_sourcing.core.event import DomainEvent, EventEnvelope, EventMetadata
+from event_sourcing.core.process_manager import ProcessManager
+
+
+# ============================================================================
+# Test Events
+# ============================================================================
+
+
+class TaskCreatedEvent(DomainEvent):
+    """Test event."""
+
+    event_type = "TaskCreatedEvent"
+    task_id: str
+
+
+# ============================================================================
+# Test ProcessManager Implementation
+# ============================================================================
+
+
+class TodoProcessManager(ProcessManager):
+    """Concrete ProcessManager for testing.
+
+    Projection side: writes todo items to an in-memory list.
+    Processor side: marks items as done and tracks call count.
+    """
+
+    def __init__(self) -> None:
+        self.pending_items: list[dict[str, object]] = []
+        self.done_items: list[dict[str, object]] = []
+        self.process_pending_calls: int = 0
+        self.handle_event_calls: int = 0
+
+    def get_name(self) -> str:
+        return "todo_pm"
+
+    def get_version(self) -> int:
+        return 1
+
+    def get_subscribed_event_types(self) -> set[str]:
+        return {"TaskCreatedEvent"}
+
+    async def handle_event(
+        self,
+        envelope: EventEnvelope[DomainEvent],
+        checkpoint_store: ProjectionCheckpointStore,
+        context: DispatchContext | None = None,
+    ) -> ProjectionResult:
+        self.handle_event_calls += 1
+        event = envelope.event
+        if isinstance(event, TaskCreatedEvent):
+            self.pending_items.append({"task_id": event.task_id, "status": "pending"})
+        return ProjectionResult.SUCCESS
+
+    async def process_pending(self) -> int:
+        self.process_pending_calls += 1
+        processed = 0
+        for item in list(self.pending_items):
+            if item["status"] == "pending":
+                item["status"] = "done"
+                self.done_items.append(item)
+                processed += 1
+        self.pending_items = [i for i in self.pending_items if i["status"] == "pending"]
+        return processed
+
+    def get_idempotency_key(self, todo_item: dict[str, object]) -> str:
+        return str(todo_item["task_id"])
+
+
+def _make_envelope(
+    event: DomainEvent,
+    global_nonce: int,
+    event_type: str = "TaskCreatedEvent",
+) -> EventEnvelope[DomainEvent]:
+    """Create a test EventEnvelope."""
+    return EventEnvelope(
+        event=event,
+        metadata=EventMetadata(
+            aggregate_nonce=1,
+            aggregate_id="test-agg-1",
+            aggregate_type="TestAggregate",
+            global_nonce=global_nonce,
+            event_type=event_type,
+        ),
+    )
+
+
+# ============================================================================
+# ProcessManager Interface Tests
+# ============================================================================
+
+
+class TestProcessManagerInterface:
+    """Tests for ProcessManager base class behavior."""
+
+    def test_is_subclass_of_checkpointed_projection(self) -> None:
+        """ProcessManager must extend CheckpointedProjection."""
+        assert issubclass(ProcessManager, CheckpointedProjection)
+
+    def test_side_effects_allowed_is_true(self) -> None:
+        """ProcessManager.SIDE_EFFECTS_ALLOWED must be True."""
+        assert ProcessManager.SIDE_EFFECTS_ALLOWED is True
+
+    def test_concrete_subclass_instantiation(self) -> None:
+        """Should instantiate a concrete ProcessManager subclass."""
+        pm = TodoProcessManager()
+        assert pm.get_name() == "todo_pm"
+        assert pm.SIDE_EFFECTS_ALLOWED is True
+
+    def test_abstract_methods_enforced(self) -> None:
+        """Cannot instantiate ProcessManager without implementing all methods."""
+
+        class IncompleteManager(ProcessManager):
+            def get_name(self) -> str:
+                return "incomplete"
+
+            def get_version(self) -> int:
+                return 1
+
+            def get_subscribed_event_types(self) -> set[str]:
+                return set()
+
+            # Missing: handle_event, process_pending, get_idempotency_key
+
+        with pytest.raises(TypeError, match="abstract"):
+            IncompleteManager()  # type: ignore[abstract]
+
+
+# ============================================================================
+# ProcessManager Projection Side Tests
+# ============================================================================
+
+
+class TestProcessManagerProjectionSide:
+    """Tests for the projection side of ProcessManager (handle_event)."""
+
+    @pytest.mark.asyncio
+    async def test_handle_event_writes_todo(self) -> None:
+        """handle_event() should write to-do records."""
+        pm = TodoProcessManager()
+        event = TaskCreatedEvent(task_id="t1")
+        envelope = _make_envelope(event, global_nonce=1)
+
+        from event_sourcing.stores.memory_checkpoint import MemoryCheckpointStore
+
+        store = MemoryCheckpointStore()
+        result = await pm.handle_event(envelope, store)
+
+        assert result == ProjectionResult.SUCCESS
+        assert len(pm.pending_items) == 1
+        assert pm.pending_items[0]["task_id"] == "t1"
+        assert pm.pending_items[0]["status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_handle_event_with_context(self) -> None:
+        """handle_event() should accept optional DispatchContext."""
+        pm = TodoProcessManager()
+        event = TaskCreatedEvent(task_id="t2")
+        envelope = _make_envelope(event, global_nonce=5)
+
+        from event_sourcing.stores.memory_checkpoint import MemoryCheckpointStore
+
+        store = MemoryCheckpointStore()
+        ctx = DispatchContext(is_catching_up=True, global_nonce=5, live_boundary_nonce=100)
+        result = await pm.handle_event(envelope, store, ctx)
+
+        assert result == ProjectionResult.SUCCESS
+        assert pm.handle_event_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_handle_event_without_context(self) -> None:
+        """handle_event() should work without context (backwards-compatible)."""
+        pm = TodoProcessManager()
+        event = TaskCreatedEvent(task_id="t3")
+        envelope = _make_envelope(event, global_nonce=1)
+
+        from event_sourcing.stores.memory_checkpoint import MemoryCheckpointStore
+
+        store = MemoryCheckpointStore()
+        result = await pm.handle_event(envelope, store)
+
+        assert result == ProjectionResult.SUCCESS
+
+
+# ============================================================================
+# ProcessManager Processor Side Tests
+# ============================================================================
+
+
+class TestProcessManagerProcessorSide:
+    """Tests for the processor side of ProcessManager (process_pending)."""
+
+    @pytest.mark.asyncio
+    async def test_process_pending_executes_items(self) -> None:
+        """process_pending() should execute pending items."""
+        pm = TodoProcessManager()
+        pm.pending_items = [
+            {"task_id": "t1", "status": "pending"},
+            {"task_id": "t2", "status": "pending"},
+        ]
+
+        processed = await pm.process_pending()
+
+        assert processed == 2
+        assert len(pm.pending_items) == 0
+        assert len(pm.done_items) == 2
+
+    @pytest.mark.asyncio
+    async def test_process_pending_is_idempotent(self) -> None:
+        """process_pending() called twice should process items only once."""
+        pm = TodoProcessManager()
+        pm.pending_items = [{"task_id": "t1", "status": "pending"}]
+
+        first = await pm.process_pending()
+        second = await pm.process_pending()
+
+        assert first == 1
+        assert second == 0  # Nothing left to process
+
+    @pytest.mark.asyncio
+    async def test_process_pending_empty(self) -> None:
+        """process_pending() with no pending items returns 0."""
+        pm = TodoProcessManager()
+        assert await pm.process_pending() == 0
+
+    def test_idempotency_key(self) -> None:
+        """get_idempotency_key() should return stable dedup key."""
+        pm = TodoProcessManager()
+        key = pm.get_idempotency_key({"task_id": "t1"})
+        assert key == "t1"
+        # Same input, same key
+        assert pm.get_idempotency_key({"task_id": "t1"}) == key

--- a/event-sourcing/python/uv.lock
+++ b/event-sourcing/python/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-04-01T04:43:36Z"
+exclude-newer = "2026-04-02T20:32:25Z"
 
 [[package]]
 name = "annotated-types"
@@ -129,7 +129,7 @@ toml = [
 
 [[package]]
 name = "event-sourcing-python"
-version = "0.11.3"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "protobuf" },
@@ -499,27 +499,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.8"
+version = "0.15.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/14/b0/73cf7550861e2b4824950b8b52eebdcc5adc792a00c514406556c5b80817/ruff-0.15.8.tar.gz", hash = "sha256:995f11f63597ee362130d1d5a327a87cb6f3f5eae3094c620bcc632329a4d26e", size = 4610921, upload-time = "2026-03-26T18:39:38.675Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/97/e9f1ca355108ef7194e38c812ef40ba98c7208f47b13ad78d023caa583da/ruff-0.15.9.tar.gz", hash = "sha256:29cbb1255a9797903f6dde5ba0188c707907ff44a9006eb273b5a17bfa0739a2", size = 4617361, upload-time = "2026-04-02T18:17:20.829Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/92/c445b0cd6da6e7ae51e954939cb69f97e008dbe750cfca89b8cedc081be7/ruff-0.15.8-py3-none-linux_armv6l.whl", hash = "sha256:cbe05adeba76d58162762d6b239c9056f1a15a55bd4b346cfd21e26cd6ad7bc7", size = 10527394, upload-time = "2026-03-26T18:39:41.566Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/92/f1c662784d149ad1414cae450b082cf736430c12ca78367f20f5ed569d65/ruff-0.15.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d3e3d0b6ba8dca1b7ef9ab80a28e840a20070c4b62e56d675c24f366ef330570", size = 10905693, upload-time = "2026-03-26T18:39:30.364Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/f2/7a631a8af6d88bcef997eb1bf87cc3da158294c57044aafd3e17030613de/ruff-0.15.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6ee3ae5c65a42f273f126686353f2e08ff29927b7b7e203b711514370d500de3", size = 10323044, upload-time = "2026-03-26T18:39:33.37Z" },
-    { url = "https://files.pythonhosted.org/packages/67/18/1bf38e20914a05e72ef3b9569b1d5c70a7ef26cd188d69e9ca8ef588d5bf/ruff-0.15.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fdce027ada77baa448077ccc6ebb2fa9c3c62fd110d8659d601cf2f475858d94", size = 10629135, upload-time = "2026-03-26T18:39:44.142Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/e9/138c150ff9af60556121623d41aba18b7b57d95ac032e177b6a53789d279/ruff-0.15.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12e617fc01a95e5821648a6df341d80456bd627bfab8a829f7cfc26a14a4b4a3", size = 10348041, upload-time = "2026-03-26T18:39:52.178Z" },
-    { url = "https://files.pythonhosted.org/packages/02/f1/5bfb9298d9c323f842c5ddeb85f1f10ef51516ac7a34ba446c9347d898df/ruff-0.15.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:432701303b26416d22ba696c39f2c6f12499b89093b61360abc34bcc9bf07762", size = 11121987, upload-time = "2026-03-26T18:39:55.195Z" },
-    { url = "https://files.pythonhosted.org/packages/10/11/6da2e538704e753c04e8d86b1fc55712fdbdcc266af1a1ece7a51fff0d10/ruff-0.15.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d910ae974b7a06a33a057cb87d2a10792a3b2b3b35e33d2699fdf63ec8f6b17a", size = 11951057, upload-time = "2026-03-26T18:39:19.18Z" },
-    { url = "https://files.pythonhosted.org/packages/83/f0/c9208c5fd5101bf87002fed774ff25a96eea313d305f1e5d5744698dc314/ruff-0.15.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2033f963c43949d51e6fdccd3946633c6b37c484f5f98c3035f49c27395a8ab8", size = 11464613, upload-time = "2026-03-26T18:40:06.301Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/22/d7f2fabdba4fae9f3b570e5605d5eb4500dcb7b770d3217dca4428484b17/ruff-0.15.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f29b989a55572fb885b77464cf24af05500806ab4edf9a0fd8977f9759d85b1", size = 11257557, upload-time = "2026-03-26T18:39:57.972Z" },
-    { url = "https://files.pythonhosted.org/packages/71/8c/382a9620038cf6906446b23ce8632ab8c0811b8f9d3e764f58bedd0c9a6f/ruff-0.15.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:ac51d486bf457cdc985a412fb1801b2dfd1bd8838372fc55de64b1510eff4bec", size = 11169440, upload-time = "2026-03-26T18:39:22.205Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/0d/0994c802a7eaaf99380085e4e40c845f8e32a562e20a38ec06174b52ef24/ruff-0.15.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c9861eb959edab053c10ad62c278835ee69ca527b6dcd72b47d5c1e5648964f6", size = 10605963, upload-time = "2026-03-26T18:39:46.682Z" },
-    { url = "https://files.pythonhosted.org/packages/19/aa/d624b86f5b0aad7cef6bbf9cd47a6a02dfdc4f72c92a337d724e39c9d14b/ruff-0.15.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8d9a5b8ea13f26ae90838afc33f91b547e61b794865374f114f349e9036835fb", size = 10357484, upload-time = "2026-03-26T18:39:49.176Z" },
-    { url = "https://files.pythonhosted.org/packages/35/c3/e0b7835d23001f7d999f3895c6b569927c4d39912286897f625736e1fd04/ruff-0.15.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c2a33a529fb3cbc23a7124b5c6ff121e4d6228029cba374777bd7649cc8598b8", size = 10830426, upload-time = "2026-03-26T18:40:03.702Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/51/ab20b322f637b369383adc341d761eaaa0f0203d6b9a7421cd6e783d81b9/ruff-0.15.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:75e5cd06b1cf3f47a3996cfc999226b19aa92e7cce682dcd62f80d7035f98f49", size = 11345125, upload-time = "2026-03-26T18:39:27.799Z" },
-    { url = "https://files.pythonhosted.org/packages/37/e6/90b2b33419f59d0f2c4c8a48a4b74b460709a557e8e0064cf33ad894f983/ruff-0.15.8-py3-none-win32.whl", hash = "sha256:bc1f0a51254ba21767bfa9a8b5013ca8149dcf38092e6a9eb704d876de94dc34", size = 10571959, upload-time = "2026-03-26T18:39:36.117Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/a2/ef467cb77099062317154c63f234b8a7baf7cb690b99af760c5b68b9ee7f/ruff-0.15.8-py3-none-win_amd64.whl", hash = "sha256:04f79eff02a72db209d47d665ba7ebcad609d8918a134f86cb13dd132159fc89", size = 11743893, upload-time = "2026-03-26T18:39:25.01Z" },
-    { url = "https://files.pythonhosted.org/packages/15/e2/77be4fff062fa78d9b2a4dea85d14785dac5f1d0c1fb58ed52331f0ebe28/ruff-0.15.8-py3-none-win_arm64.whl", hash = "sha256:cf891fa8e3bb430c0e7fac93851a5978fc99c8fa2c053b57b118972866f8e5f2", size = 11048175, upload-time = "2026-03-26T18:40:01.06Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1f/9cdfd0ac4b9d1e5a6cf09bedabdf0b56306ab5e333c85c87281273e7b041/ruff-0.15.9-py3-none-linux_armv6l.whl", hash = "sha256:6efbe303983441c51975c243e26dff328aca11f94b70992f35b093c2e71801e1", size = 10511206, upload-time = "2026-04-02T18:16:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/f6/32bfe3e9c136b35f02e489778d94384118bb80fd92c6d92e7ccd97db12ce/ruff-0.15.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4965bac6ac9ea86772f4e23587746f0b7a395eccabb823eb8bfacc3fa06069f7", size = 10923307, upload-time = "2026-04-02T18:17:08.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/25/de55f52ab5535d12e7aaba1de37a84be6179fb20bddcbe71ec091b4a3243/ruff-0.15.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:eaf05aad70ca5b5a0a4b0e080df3a6b699803916d88f006efd1f5b46302daab8", size = 10316722, upload-time = "2026-04-02T18:16:44.206Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/690d75f3fd6278fe55fff7c9eb429c92d207e14b25d1cae4064a32677029/ruff-0.15.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9439a342adb8725f32f92732e2bafb6d5246bd7a5021101166b223d312e8fc59", size = 10623674, upload-time = "2026-04-02T18:16:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/ec/176f6987be248fc5404199255522f57af1b4a5a1b57727e942479fec98ad/ruff-0.15.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9c5e6faf9d97c8edc43877c3f406f47446fc48c40e1442d58cfcdaba2acea745", size = 10351516, upload-time = "2026-04-02T18:16:57.206Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fc/51cffbd2b3f240accc380171d51446a32aa2ea43a40d4a45ada67368fbd2/ruff-0.15.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b34a9766aeec27a222373d0b055722900fbc0582b24f39661aa96f3fe6ad901", size = 11150202, upload-time = "2026-04-02T18:17:06.452Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d4/25292a6dfc125f6b6528fe6af31f5e996e19bf73ca8e3ce6eb7fa5b95885/ruff-0.15.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:89dd695bc72ae76ff484ae54b7e8b0f6b50f49046e198355e44ea656e521fef9", size = 11988891, upload-time = "2026-04-02T18:17:18.575Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e1/1eebcb885c10e19f969dcb93d8413dfee8172578709d7ee933640f5e7147/ruff-0.15.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce187224ef1de1bd225bc9a152ac7102a6171107f026e81f317e4257052916d5", size = 11480576, upload-time = "2026-04-02T18:16:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6b/a1548ac378a78332a4c3dcf4a134c2475a36d2a22ddfa272acd574140b50/ruff-0.15.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b0c7c341f68adb01c488c3b7d4b49aa8ea97409eae6462d860a79cf55f431b6", size = 11254525, upload-time = "2026-04-02T18:17:02.041Z" },
+    { url = "https://files.pythonhosted.org/packages/42/aa/4bb3af8e61acd9b1281db2ab77e8b2c3c5e5599bf2a29d4a942f1c62b8d6/ruff-0.15.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:55cc15eee27dc0eebdfcb0d185a6153420efbedc15eb1d38fe5e685657b0f840", size = 11204072, upload-time = "2026-04-02T18:17:13.581Z" },
+    { url = "https://files.pythonhosted.org/packages/69/48/d550dc2aa6e423ea0bcc1d0ff0699325ffe8a811e2dba156bd80750b86dc/ruff-0.15.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6537f6eed5cda688c81073d46ffdfb962a5f29ecb6f7e770b2dc920598997ed", size = 10594998, upload-time = "2026-04-02T18:16:46.369Z" },
+    { url = "https://files.pythonhosted.org/packages/63/47/321167e17f5344ed5ec6b0aa2cff64efef5f9e985af8f5622cfa6536043f/ruff-0.15.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6d3fcbca7388b066139c523bda744c822258ebdcfbba7d24410c3f454cc9af71", size = 10359769, upload-time = "2026-04-02T18:17:10.994Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5e/074f00b9785d1d2c6f8c22a21e023d0c2c1817838cfca4c8243200a1fa87/ruff-0.15.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:058d8e99e1bfe79d8a0def0b481c56059ee6716214f7e425d8e737e412d69677", size = 10850236, upload-time = "2026-04-02T18:16:48.749Z" },
+    { url = "https://files.pythonhosted.org/packages/76/37/804c4135a2a2caf042925d30d5f68181bdbd4461fd0d7739da28305df593/ruff-0.15.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8e1ddb11dbd61d5983fa2d7d6370ef3eb210951e443cace19594c01c72abab4c", size = 11358343, upload-time = "2026-04-02T18:16:55.068Z" },
+    { url = "https://files.pythonhosted.org/packages/88/3d/1364fcde8656962782aa9ea93c92d98682b1ecec2f184e625a965ad3b4a6/ruff-0.15.9-py3-none-win32.whl", hash = "sha256:bde6ff36eaf72b700f32b7196088970bf8fdb2b917b7accd8c371bfc0fd573ec", size = 10583382, upload-time = "2026-04-02T18:17:04.261Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/56/5c7084299bd2cacaa07ae63a91c6f4ba66edc08bf28f356b24f6b717c799/ruff-0.15.9-py3-none-win_amd64.whl", hash = "sha256:45a70921b80e1c10cf0b734ef09421f71b5aa11d27404edc89d7e8a69505e43d", size = 11744969, upload-time = "2026-04-02T18:16:59.611Z" },
+    { url = "https://files.pythonhosted.org/packages/03/36/76704c4f312257d6dbaae3c959add2a622f63fcca9d864659ce6d8d97d3d/ruff-0.15.9-py3-none-win_arm64.whl", hash = "sha256:0694e601c028fd97dc5c6ee244675bc241aeefced7ef80cd9c6935a871078f53", size = 11005870, upload-time = "2026-04-02T18:17:15.773Z" },
 ]
 
 [[package]]

--- a/event-store/Cargo.lock
+++ b/event-store/Cargo.lock
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "eventstore-backend-memory"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "eventstore-core",
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "eventstore-backend-postgres"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "eventstore-bin"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "eventstore-backend-memory",
@@ -616,7 +616,7 @@ dependencies = [
 
 [[package]]
 name = "eventstore-core"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "eventstore-proto"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "prost",
  "prost-types",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "eventstore-sdk-rs"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "eventstore-backend-memory",
@@ -935,7 +935,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -957,7 +957,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -1991,7 +1991,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls 0.23.37",
@@ -2051,9 +2051,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",

--- a/package.json
+++ b/package.json
@@ -20,5 +20,10 @@
   "devDependencies": {
     "turbo": "^2.9.3"
   },
+  "pnpm": {
+    "overrides": {
+      "follow-redirects": ">=1.16.0"
+    }
+  },
   "packageManager": "pnpm@10.20.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  follow-redirects: '>=1.16.0'
+
 importers:
 
   .:
@@ -4488,8 +4491,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -13581,7 +13584,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.15.11(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
       debug: 4.4.3
 
@@ -14009,7 +14012,7 @@ snapshots:
   http-proxy@1.18.1(debug@4.4.3):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.4.3)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug

--- a/vsa/vsa-cli/src/templates/context.rs
+++ b/vsa/vsa-cli/src/templates/context.rs
@@ -375,6 +375,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: ValidationConfig::default(),
             patterns: PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         }
     }
 

--- a/vsa/vsa-cli/src/templates/engine.rs
+++ b/vsa/vsa-cli/src/templates/engine.rs
@@ -223,6 +223,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: ValidationConfig::default(),
             patterns: PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         }
     }
 
@@ -261,6 +262,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: ValidationConfig::default(),
             patterns: PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         }
     }
 

--- a/vsa/vsa-core/src/config.rs
+++ b/vsa/vsa-core/src/config.rs
@@ -49,6 +49,12 @@ pub struct VsaConfig {
     /// Pattern definitions
     #[serde(default)]
     pub patterns: PatternsConfig,
+
+    /// Additional allowed module prefixes for projection purity checks (VSA032).
+    /// Merged with the default whitelist (stdlib + event_sourcing).
+    /// Example: ["syn_domain", "syn_shared", "syn_adapters.projection_stores"]
+    #[serde(default)]
+    pub projection_allowed_prefixes: Option<Vec<String>>,
 }
 
 /// Architecture type
@@ -1205,6 +1211,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: ValidationConfig::default(),
             patterns: PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         };
 
         assert!(config.validate().is_ok());
@@ -1225,6 +1232,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: ValidationConfig::default(),
             patterns: PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         };
 
         assert!(config.validate().is_ok());
@@ -1246,6 +1254,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: ValidationConfig::default(),
             patterns: PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         };
 
         assert!(config.validate().is_err());
@@ -1265,6 +1274,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: ValidationConfig::default(),
             patterns: PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         };
 
         assert!(config.validate().is_err());
@@ -1284,6 +1294,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: ValidationConfig::default(),
             patterns: PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         };
 
         assert!(config.validate().is_err());

--- a/vsa/vsa-core/src/scanner.rs
+++ b/vsa/vsa-core/src/scanner.rs
@@ -171,6 +171,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: ValidationConfig::default(),
             patterns: PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         }
     }
 

--- a/vsa/vsa-core/src/validation/bounded_context_rules.rs
+++ b/vsa/vsa-core/src/validation/bounded_context_rules.rs
@@ -359,6 +359,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: ValidationConfig::default(),
             patterns: PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         }
     }
 

--- a/vsa/vsa-core/src/validation/consumer_pattern_rules.rs
+++ b/vsa/vsa-core/src/validation/consumer_pattern_rules.rs
@@ -1,0 +1,410 @@
+//! Consumer pattern validation rules for event sourcing
+//!
+//! These rules enforce the correct use of event consumer patterns:
+//! - Projections must be pure (no side-effecting imports)
+//! - ProcessManagers must implement required methods
+//!
+//! See CONSUMER-PATTERNS.md and ADR-025 for the architectural rationale.
+
+use super::import_parser::parse_imports;
+use super::{
+    is_test_or_conftest, EnhancedValidationReport, Severity, Suggestion, ValidationContext,
+    ValidationIssue, ValidationRule,
+};
+use crate::error::Result;
+use crate::scanner::Scanner;
+use std::collections::HashSet;
+
+// ============================================================================
+// Projection Purity Whitelist
+// ============================================================================
+
+/// Default allowed module prefixes for projections.
+/// Matches event_sourcing.fitness.projection_purity.PROJECTION_ALLOWED_PREFIXES.
+fn default_projection_allowed_prefixes() -> HashSet<&'static str> {
+    [
+        // Python stdlib (pure, no side effects)
+        "__future__",
+        "abc",
+        "collections",
+        "dataclasses",
+        "datetime",
+        "decimal",
+        "enum",
+        "functools",
+        "logging",
+        "math",
+        "operator",
+        "re",
+        "typing",
+        "typing_extensions",
+        "uuid",
+        // ESP framework itself
+        "event_sourcing",
+    ]
+    .into_iter()
+    .collect()
+}
+
+/// Check if a module name matches any allowed prefix.
+fn is_allowed_import(module: &str, allowed: &HashSet<&str>) -> bool {
+    for prefix in allowed {
+        if module == *prefix || module.starts_with(&format!("{}.", prefix)) {
+            return true;
+        }
+    }
+    // Relative imports are always allowed (same-package)
+    module.starts_with('.')
+}
+
+// ============================================================================
+// VSA032: Projection Purity Rule
+// ============================================================================
+
+/// Rule: Projection files must only import from whitelisted modules.
+///
+/// Uses a whitelist approach (CSP-style default-deny). Any runtime import
+/// whose top-level module is not in the allowed set is a violation.
+/// Imports inside `if TYPE_CHECKING:` blocks are not checked by the
+/// line-based parser, so they pass through safely.
+///
+/// The rule scans for Python files in `slices/` directories that have
+/// "projection" in their filename or path, checking their imports against
+/// the whitelist.
+///
+/// Projects can extend the whitelist via `vsa.yaml` configuration
+/// (projection_allowed_prefixes).
+pub struct ProjectionPurityRule;
+
+impl ValidationRule for ProjectionPurityRule {
+    fn name(&self) -> &str {
+        "projection-purity"
+    }
+
+    fn code(&self) -> &str {
+        "VSA032"
+    }
+
+    fn validate(
+        &self,
+        ctx: &ValidationContext,
+        report: &mut EnhancedValidationReport,
+    ) -> Result<()> {
+        let scanner = Scanner::new(ctx.config.clone(), ctx.root.clone());
+        let contexts = scanner.scan_contexts()?;
+
+        let mut allowed = default_projection_allowed_prefixes();
+
+        // Add project-specific allowed prefixes from config
+        if let Some(ref extra) = ctx.config.projection_allowed_prefixes {
+            for prefix in extra {
+                // Leak to get 'static lifetime - these live for the duration of validation
+                allowed.insert(Box::leak(prefix.clone().into_boxed_str()));
+            }
+        }
+
+        for context in contexts {
+            let slices_path = context.path.join("slices");
+            if !slices_path.exists() {
+                continue;
+            }
+
+            // Find projection files in slices/
+            for entry in walkdir::WalkDir::new(&slices_path)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_type().is_file())
+            {
+                let file_path = entry.path();
+
+                // Only check Python files
+                if file_path.extension().and_then(|e| e.to_str()) != Some("py") {
+                    continue;
+                }
+
+                // Skip test files
+                if is_test_or_conftest(file_path) {
+                    continue;
+                }
+
+                // Check if this is a projection file (by name or path)
+                if !Self::is_projection_file(file_path) {
+                    continue;
+                }
+
+                // Parse imports and check against whitelist
+                let imports = match parse_imports(file_path) {
+                    Ok(imports) => imports,
+                    Err(_) => continue,
+                };
+
+                for import in imports {
+                    if import.is_relative {
+                        continue; // Relative imports are always fine
+                    }
+
+                    if !is_allowed_import(&import.module, &allowed) {
+                        let relative_path =
+                            file_path.strip_prefix(&ctx.root).unwrap_or(file_path);
+
+                        report.errors.push(ValidationIssue {
+                            path: file_path.to_path_buf(),
+                            code: self.code().to_string(),
+                            severity: Severity::Error,
+                            message: format!(
+                                "Projection file '{}' imports non-whitelisted module: '{}' (line {})\n\
+                                 Projections must be pure - replaying events must produce zero side effects.\n\
+                                 See CONSUMER-PATTERNS.md for allowed imports.",
+                                relative_path.display(),
+                                import.module,
+                                import.line_number,
+                            ),
+                            suggestions: vec![
+                                Suggestion::manual(
+                                    "Remove this import. Projections should only use pure stdlib modules and event_sourcing.",
+                                ),
+                                Suggestion::manual(
+                                    "If this import is needed, move the side-effecting logic to a ProcessManager instead.",
+                                ),
+                                Suggestion::manual(
+                                    "If this module is safe (no side effects), add it to projection_allowed_prefixes in vsa.yaml.",
+                                ),
+                            ],
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl ProjectionPurityRule {
+    /// Check if a file is a projection file based on naming conventions.
+    fn is_projection_file(path: &std::path::Path) -> bool {
+        let file_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("")
+            .to_lowercase();
+
+        // Direct name match
+        if file_name.contains("projection") {
+            return true;
+        }
+
+        // Check parent directory name
+        if let Some(parent) = path.parent() {
+            let parent_name = parent
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("")
+                .to_lowercase();
+            if parent_name.contains("projection") {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+// ============================================================================
+// VSA033: ProcessManager Structure Rule
+// ============================================================================
+
+/// Rule: ProcessManager subclasses must implement required methods.
+///
+/// Scans Python files that contain `ProcessManager` in their class
+/// hierarchy and verifies they define:
+/// - `def process_pending(self` - the processor side
+/// - `def get_idempotency_key(self` - stable dedup key
+///
+/// Uses string scanning (consistent with existing VSA parser approach).
+pub struct ProcessManagerStructureRule;
+
+impl ValidationRule for ProcessManagerStructureRule {
+    fn name(&self) -> &str {
+        "process-manager-structure"
+    }
+
+    fn code(&self) -> &str {
+        "VSA033"
+    }
+
+    fn validate(
+        &self,
+        ctx: &ValidationContext,
+        report: &mut EnhancedValidationReport,
+    ) -> Result<()> {
+        let scanner = Scanner::new(ctx.config.clone(), ctx.root.clone());
+        let contexts = scanner.scan_contexts()?;
+
+        for context in contexts {
+            let slices_path = context.path.join("slices");
+            if !slices_path.exists() {
+                continue;
+            }
+
+            for entry in walkdir::WalkDir::new(&slices_path)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_type().is_file())
+            {
+                let file_path = entry.path();
+
+                // Only check Python files
+                if file_path.extension().and_then(|e| e.to_str()) != Some("py") {
+                    continue;
+                }
+
+                // Skip test files
+                if is_test_or_conftest(file_path) {
+                    continue;
+                }
+
+                let source = match std::fs::read_to_string(file_path) {
+                    Ok(s) => s,
+                    Err(_) => continue,
+                };
+
+                // Check if this file defines a ProcessManager subclass
+                if !Self::is_process_manager_file(&source) {
+                    continue;
+                }
+
+                let relative_path = file_path.strip_prefix(&ctx.root).unwrap_or(file_path);
+
+                // Check for required methods
+                if !source.contains("def process_pending(self") {
+                    report.errors.push(ValidationIssue {
+                        path: file_path.to_path_buf(),
+                        code: self.code().to_string(),
+                        severity: Severity::Error,
+                        message: format!(
+                            "ProcessManager in '{}' is missing required method 'process_pending()'\n\
+                             ProcessManagers must implement process_pending() for the processor side.\n\
+                             See CONSUMER-PATTERNS.md for the To-Do List pattern.",
+                            relative_path.display(),
+                        ),
+                        suggestions: vec![Suggestion::manual(
+                            "Add: async def process_pending(self) -> int: ...",
+                        )],
+                    });
+                }
+
+                if !source.contains("def get_idempotency_key(self") {
+                    report.errors.push(ValidationIssue {
+                        path: file_path.to_path_buf(),
+                        code: self.code().to_string(),
+                        severity: Severity::Error,
+                        message: format!(
+                            "ProcessManager in '{}' is missing required method 'get_idempotency_key()'\n\
+                             ProcessManagers must provide a stable dedup key for each to-do item.\n\
+                             See CONSUMER-PATTERNS.md.",
+                            relative_path.display(),
+                        ),
+                        suggestions: vec![Suggestion::manual(
+                            "Add: def get_idempotency_key(self, todo_item: dict[str, object]) -> str: ...",
+                        )],
+                    });
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl ProcessManagerStructureRule {
+    /// Check if source code defines a class that extends ProcessManager.
+    fn is_process_manager_file(source: &str) -> bool {
+        for line in source.lines() {
+            let trimmed = line.trim();
+            // Match class definitions that inherit from ProcessManager
+            if trimmed.starts_with("class ")
+                && trimmed.contains("ProcessManager")
+                && trimmed.contains('(')
+            {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_allowed_import() {
+        let allowed = default_projection_allowed_prefixes();
+
+        // Allowed
+        assert!(is_allowed_import("typing", &allowed));
+        assert!(is_allowed_import("typing.Optional", &allowed)); // matches "typing" prefix
+        assert!(is_allowed_import("logging", &allowed));
+        assert!(is_allowed_import("event_sourcing", &allowed));
+        assert!(is_allowed_import("event_sourcing.core.checkpoint", &allowed));
+        assert!(is_allowed_import("datetime", &allowed));
+        assert!(is_allowed_import("uuid", &allowed));
+        assert!(is_allowed_import(".relative_import", &allowed)); // relative always ok
+
+        // Not allowed
+        assert!(!is_allowed_import("httpx", &allowed));
+        assert!(!is_allowed_import("requests", &allowed));
+        assert!(!is_allowed_import("docker", &allowed));
+        assert!(!is_allowed_import("boto3", &allowed));
+        assert!(!is_allowed_import("subprocess", &allowed));
+        assert!(!is_allowed_import("aiohttp", &allowed));
+    }
+
+    #[test]
+    fn test_is_projection_file() {
+        use std::path::Path;
+
+        // Match by file name
+        assert!(ProjectionPurityRule::is_projection_file(Path::new(
+            "slices/orders/projection.py"
+        )));
+        assert!(ProjectionPurityRule::is_projection_file(Path::new(
+            "slices/orders/OrderSummaryProjection.py"
+        )));
+        assert!(ProjectionPurityRule::is_projection_file(Path::new(
+            "slices/orders/order_projection.py"
+        )));
+
+        // Match by parent directory
+        assert!(ProjectionPurityRule::is_projection_file(Path::new(
+            "slices/orders/projection/handler.py"
+        )));
+
+        // No match
+        assert!(!ProjectionPurityRule::is_projection_file(Path::new(
+            "slices/orders/handler.py"
+        )));
+        assert!(!ProjectionPurityRule::is_projection_file(Path::new(
+            "slices/orders/aggregate.py"
+        )));
+    }
+
+    #[test]
+    fn test_is_process_manager_file() {
+        assert!(ProcessManagerStructureRule::is_process_manager_file(
+            "class WorkflowDispatchManager(ProcessManager):"
+        ));
+        assert!(ProcessManagerStructureRule::is_process_manager_file(
+            "class MyManager(ProcessManager, SomeMixin):"
+        ));
+        // Not a ProcessManager
+        assert!(!ProcessManagerStructureRule::is_process_manager_file(
+            "class OrderProjection(CheckpointedProjection):"
+        ));
+        // Just mentioning ProcessManager in a comment
+        assert!(!ProcessManagerStructureRule::is_process_manager_file(
+            "# This should use ProcessManager instead"
+        ));
+    }
+}

--- a/vsa/vsa-core/src/validation/consumer_pattern_rules.rs
+++ b/vsa/vsa-core/src/validation/consumer_pattern_rules.rs
@@ -21,7 +21,7 @@ use std::collections::HashSet;
 
 /// Default allowed module prefixes for projections.
 /// Matches event_sourcing.fitness.projection_purity.PROJECTION_ALLOWED_PREFIXES.
-fn default_projection_allowed_prefixes() -> HashSet<&'static str> {
+fn default_projection_allowed_prefixes() -> HashSet<String> {
     [
         // Python stdlib (pure, no side effects)
         "__future__",
@@ -43,13 +43,14 @@ fn default_projection_allowed_prefixes() -> HashSet<&'static str> {
         "event_sourcing",
     ]
     .into_iter()
+    .map(String::from)
     .collect()
 }
 
 /// Check if a module name matches any allowed prefix.
-fn is_allowed_import(module: &str, allowed: &HashSet<&str>) -> bool {
+fn is_allowed_import(module: &str, allowed: &HashSet<String>) -> bool {
     for prefix in allowed {
-        if module == *prefix || module.starts_with(&format!("{}.", prefix)) {
+        if module == prefix.as_str() || module.starts_with(&format!("{}.", prefix)) {
             return true;
         }
     }
@@ -65,8 +66,8 @@ fn is_allowed_import(module: &str, allowed: &HashSet<&str>) -> bool {
 ///
 /// Uses a whitelist approach (CSP-style default-deny). Any runtime import
 /// whose top-level module is not in the allowed set is a violation.
-/// Imports inside `if TYPE_CHECKING:` blocks are not checked by the
-/// line-based parser, so they pass through safely.
+/// Imports inside `if TYPE_CHECKING:` blocks are excluded by the
+/// line-based parser via indentation-based block detection.
 ///
 /// The rule scans for Python files in `slices/` directories that have
 /// "projection" in their filename or path, checking their imports against
@@ -98,8 +99,7 @@ impl ValidationRule for ProjectionPurityRule {
         // Add project-specific allowed prefixes from config
         if let Some(ref extra) = ctx.config.projection_allowed_prefixes {
             for prefix in extra {
-                // Leak to get 'static lifetime - these live for the duration of validation
-                allowed.insert(Box::leak(prefix.clone().into_boxed_str()));
+                allowed.insert(prefix.clone());
             }
         }
 

--- a/vsa/vsa-core/src/validation/dependency_rules.rs
+++ b/vsa/vsa-core/src/validation/dependency_rules.rs
@@ -640,6 +640,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: crate::config::ValidationConfig::default(),
             patterns: crate::config::PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         };
         let ctx = ValidationContext::new(config, temp_dir.path().to_path_buf());
         (temp_dir, ctx)
@@ -1002,6 +1003,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: crate::config::ValidationConfig::default(),
             patterns: crate::config::PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         };
         config.validation.exclude_from_isolation =
             vec!["list_repos".to_string()];
@@ -1048,6 +1050,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: crate::config::ValidationConfig::default(),
             patterns: crate::config::PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         };
         // Exclude list_repos but NOT other_slice
         config.validation.exclude_from_isolation =

--- a/vsa/vsa-core/src/validation/import_parser.rs
+++ b/vsa/vsa-core/src/validation/import_parser.rs
@@ -454,6 +454,51 @@ from domain.WorkflowAggregate import WorkflowAggregate
         assert_eq!(imports[0].module, "domain.WorkflowAggregate");
     }
 
+    #[test]
+    fn test_python_type_checking_block_excluded() {
+        let parser = PythonImportParser::new();
+        let source = r#"
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from event_sourcing.core.checkpoint import CheckpointedProjection
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+    from boto3 import Session
+
+from datetime import datetime
+"#;
+        let imports = parser.parse_source(source);
+
+        // Should have 4 imports: __future__, typing, event_sourcing, datetime
+        // httpx and boto3 are inside TYPE_CHECKING and should be excluded
+        assert_eq!(imports.len(), 4);
+        assert_eq!(imports[0].module, "__future__");
+        assert_eq!(imports[1].module, "typing");
+        assert_eq!(imports[2].module, "event_sourcing.core.checkpoint");
+        assert_eq!(imports[3].module, "datetime");
+    }
+
+    #[test]
+    fn test_python_type_checking_block_with_typing_prefix() {
+        let parser = PythonImportParser::new();
+        let source = r#"
+import typing
+
+if typing.TYPE_CHECKING:
+    from httpx import AsyncClient
+
+from uuid import uuid4
+"#;
+        let imports = parser.parse_source(source);
+
+        assert_eq!(imports.len(), 2);
+        assert_eq!(imports[0].module, "typing");
+        assert_eq!(imports[1].module, "uuid");
+    }
+
     // ========================================================================
     // TYPESCRIPT IMPORT PARSER TESTS
     // ========================================================================

--- a/vsa/vsa-core/src/validation/import_parser.rs
+++ b/vsa/vsa-core/src/validation/import_parser.rs
@@ -76,6 +76,8 @@ impl ImportParser for PythonImportParser {
 
     fn parse_source(&self, source: &str) -> Vec<ImportStatement> {
         let mut imports = Vec::new();
+        let mut in_type_checking_block = false;
+        let mut type_checking_indent: Option<usize> = None;
 
         for (line_num, line) in source.lines().enumerate() {
             let trimmed = line.trim();
@@ -83,6 +85,32 @@ impl ImportParser for PythonImportParser {
             // Skip comments and empty lines
             if trimmed.starts_with('#') || trimmed.is_empty() {
                 continue;
+            }
+
+            // Detect `if TYPE_CHECKING:` blocks
+            if trimmed == "if TYPE_CHECKING:"
+                || trimmed == "if typing.TYPE_CHECKING:"
+            {
+                in_type_checking_block = true;
+                // Record the indentation level of the `if` statement
+                let indent = line.len() - line.trim_start().len();
+                type_checking_indent = Some(indent);
+                continue;
+            }
+
+            // If inside a TYPE_CHECKING block, check if we've dedented back out
+            if in_type_checking_block {
+                if let Some(base_indent) = type_checking_indent {
+                    let current_indent = line.len() - line.trim_start().len();
+                    if current_indent <= base_indent {
+                        // We've left the TYPE_CHECKING block
+                        in_type_checking_block = false;
+                        type_checking_indent = None;
+                    } else {
+                        // Still inside TYPE_CHECKING - skip this import
+                        continue;
+                    }
+                }
             }
 
             // Check for import statements

--- a/vsa/vsa-core/src/validation/integration_event_rules.rs
+++ b/vsa/vsa-core/src/validation/integration_event_rules.rs
@@ -159,6 +159,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: ValidationConfig::default(),
             patterns: PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         }
     }
 

--- a/vsa/vsa-core/src/validation/isolation_rules.rs
+++ b/vsa/vsa-core/src/validation/isolation_rules.rs
@@ -433,6 +433,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: crate::config::ValidationConfig::default(),
             patterns: crate::config::PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         }
     }
 

--- a/vsa/vsa-core/src/validation/mod.rs
+++ b/vsa/vsa-core/src/validation/mod.rs
@@ -1,6 +1,7 @@
 //! Enhanced validation system for VSA
 
 mod bounded_context_rules;
+mod consumer_pattern_rules;
 mod dependency_rules;
 mod import_parser;
 mod integration_event_rules;
@@ -15,6 +16,7 @@ pub use bounded_context_rules::{
     ContextBoundariesRule, NoCircularDependenciesRule, RequireAggregatesForBoundedContextRule,
     RequireSharedFolderRule,
 };
+pub use consumer_pattern_rules::{ProcessManagerStructureRule, ProjectionPurityRule};
 pub use dependency_rules::{
     ApplicationIsolationRule, DomainPurityRule, EventsIsolationRule, PortIsolationRule,
     SliceIsolationRule,

--- a/vsa/vsa-core/src/validation/query_slice_rules.rs
+++ b/vsa/vsa-core/src/validation/query_slice_rules.rs
@@ -222,6 +222,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: crate::config::ValidationConfig::default(),
             patterns: crate::config::PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         }
     }
 

--- a/vsa/vsa-core/src/validation/rules.rs
+++ b/vsa/vsa-core/src/validation/rules.rs
@@ -38,7 +38,8 @@ impl ValidationRuleSet {
             ApplicationIsolationRule, ContextBoundariesRule, DomainPurityRule, EventsIsolationRule,
             IntegrationEventNamingRule, IntegrationEventsLocationRule, NoCircularDependenciesRule,
             NoCrossSliceImportsRule, NoDuplicateIntegrationEventsRule, PortIsolationRule,
-            ProjectionEventSubscriptionRule, RequireAggregatesInDomainRootRule,
+            ProcessManagerStructureRule, ProjectionEventSubscriptionRule,
+            ProjectionPurityRule, RequireAggregatesInDomainRootRule,
             RequireBusesInInfrastructureRule, RequireCommandsInDomainRule,
             RequireEventsInDomainRule, RequireHandlerForQueryRule, RequirePortSuffixRule,
             RequirePortsInPortsFolderRule, RequireProjectionForQueryRule, RequireSharedFolderRule,
@@ -82,6 +83,9 @@ impl ValidationRuleSet {
             Box::new(PortIsolationRule), // VSA029: Port isolation (domain/events only)
             Box::new(ApplicationIsolationRule), // VSA030: Application isolation (no infra/slices)
             Box::new(SliceIsolationRule), // VSA031: Slice isolation (no cross-slice)
+            // Consumer pattern rules (ADR-025)
+            Box::new(ProjectionPurityRule),          // VSA032: Projection purity (whitelist)
+            Box::new(ProcessManagerStructureRule),    // VSA033: ProcessManager structure
             // Slice isolation rules (legacy)
             Box::new(NoCrossSliceImportsRule),
             Box::new(ThinAdapterRule),

--- a/vsa/vsa-core/src/validation/slice_location_rules.rs
+++ b/vsa/vsa-core/src/validation/slice_location_rules.rs
@@ -205,6 +205,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: crate::config::ValidationConfig::default(),
             patterns: crate::config::PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         }
     }
 

--- a/vsa/vsa-core/src/validation/structure_rules.rs
+++ b/vsa/vsa-core/src/validation/structure_rules.rs
@@ -1442,6 +1442,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: crate::config::ValidationConfig::default(),
             patterns: crate::config::PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         }
     }
 

--- a/vsa/vsa-core/src/validator.rs
+++ b/vsa/vsa-core/src/validator.rs
@@ -176,6 +176,7 @@ mod tests {
             contexts: HashMap::new(),
             validation: ValidationConfig::default(),
             patterns: PatternsConfig::default(),
+            projection_allowed_prefixes: None,
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `ProcessManager` base class implementing the Processor To-Do List pattern (Dilger, Ch. 37) - makes replay storm bugs structurally impossible at the framework level
- Adds `DispatchContext` with `global_nonce`-based catch-up/live boundary - coordinator passes replay awareness to all projections
- Adds `SIDE_EFFECTS_ALLOWED` ClassVar marker on `CheckpointedProjection` (False) and `ProcessManager` (True)
- Coordinator gates `process_pending()` - never called during catch-up replay
- Ships whitelist-based fitness module (`event_sourcing/fitness/`) for projection purity, ProcessManager structure, and replay safety checks
- Ships test kit extensions (`ProcessManagerScenario`, `IdempotencyVerifier`)
- Adds VSA032 (ProjectionPurityRule) and VSA033 (ProcessManagerStructureRule) to the Rust VSA validator
- Full documentation: CONSUMER-PATTERNS.md guide + ADR-025 decision record

## Context

The Syntropic137 architectural fitness audit found that 5/7 invariants are broken because ESP provides only `CheckpointedProjection` for event consumers. When a system needs event-driven side effects (dispatch workflows, call APIs), the only available base class is a projection - which runs during replay. This is the root cause of the replay storm bug that burns user funds on restart.

This PR fixes ESP so every system built on it inherits correct separation of concerns by construction. The replay storm bug becomes impossible to write, not just "caught in CI."

## Test plan

- [x] 194 Python tests pass (48 new + 146 existing unchanged)
- [x] 251 Rust tests pass (3 new + 248 existing unchanged)
- [x] Backwards compatibility: existing projections work without changes (optional context param)
- [ ] Syn137 integration: update submodule, convert WorkflowDispatchProjection to ProcessManager