### PR TITLE
feat: ProjectionStore protocols + VSA206 LayerSeparationRule

### DIFF
--- a/event-sourcing/python/pyproject.toml
+++ b/event-sourcing/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "event-sourcing-python"
-version = "0.12.0"
+version = "0.13.0"
 description = "Python SDK for Event Sourcing patterns and abstractions"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/event-sourcing/python/src/event_sourcing/__init__.py
+++ b/event-sourcing/python/src/event_sourcing/__init__.py
@@ -58,7 +58,11 @@ from event_sourcing.decorators.events import (
     get_event_type_registry,
     resolve_event_type,
 )
-from event_sourcing.stores import MemoryCheckpointStore, MemoryProjectionStore, PostgresCheckpointStore
+from event_sourcing.stores import (
+    MemoryCheckpointStore,
+    MemoryProjectionStore,
+    PostgresCheckpointStore,
+)
 from event_sourcing.subscriptions import SubscriptionCoordinator
 
 __version__ = "0.1.0"

--- a/event-sourcing/python/src/event_sourcing/__init__.py
+++ b/event-sourcing/python/src/event_sourcing/__init__.py
@@ -13,7 +13,7 @@ from event_sourcing.client import (
     MemoryEventStoreClient,
 )
 from event_sourcing.core.aggregate import AggregateRoot, BaseAggregate
-from event_sourcing.core.checkpoint import DispatchContext
+from event_sourcing.core.checkpoint import DispatchContext, ProjectionReadStore, ProjectionStore
 from event_sourcing.core.command import Command, CommandBus, CommandHandler, InMemoryCommandBus
 from event_sourcing.core.errors import (
     AggregateNotFoundError,
@@ -58,7 +58,7 @@ from event_sourcing.decorators.events import (
     get_event_type_registry,
     resolve_event_type,
 )
-from event_sourcing.stores import MemoryCheckpointStore, PostgresCheckpointStore
+from event_sourcing.stores import MemoryCheckpointStore, MemoryProjectionStore, PostgresCheckpointStore
 from event_sourcing.subscriptions import SubscriptionCoordinator
 
 __version__ = "0.1.0"
@@ -87,12 +87,16 @@ __all__ = [
     "DispatchContext",
     "ProjectionCheckpoint",
     "ProjectionCheckpointStore",
+    "ProjectionReadStore",
     "ProjectionResult",
+    "ProjectionStore",
     # Process Manager (To-Do List pattern)
     "ProcessManager",
     # Checkpoint Stores
     "PostgresCheckpointStore",
     "MemoryCheckpointStore",
+    # Projection Stores
+    "MemoryProjectionStore",
     # Subscription Coordinator
     "SubscriptionCoordinator",
     # Repository

--- a/event-sourcing/python/src/event_sourcing/core/checkpoint.py
+++ b/event-sourcing/python/src/event_sourcing/core/checkpoint.py
@@ -5,6 +5,8 @@ This module provides the core abstractions for checkpointed projections:
 - ProjectionCheckpoint: Immutable checkpoint tracking per-projection position
 - ProjectionResult: Explicit result type for event handlers
 - ProjectionCheckpointStore: Protocol for checkpoint persistence
+- ProjectionStore: Protocol for projection read-model data persistence
+- ProjectionReadStore: Read-only subset of ProjectionStore for query handlers
 - CheckpointedProjection: Abstract base class with mandatory checkpoint tracking
 - DispatchContext: Replay awareness context passed by the coordinator
 
@@ -16,7 +18,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import Enum
-from typing import TYPE_CHECKING, ClassVar, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
 
@@ -201,6 +203,143 @@ class ProjectionCheckpointStore(Protocol):
 
         Returns:
             List of all stored checkpoints
+        """
+        ...
+
+
+@runtime_checkable
+class ProjectionStore(Protocol):
+    """Protocol for projection read-model data persistence.
+
+    Complements ``ProjectionCheckpointStore`` (position tracking) with
+    actual read-model data storage. Projections write to this store
+    in ``handle_event()``; query handlers read from it.
+
+    Implementations can use any backend: PostgreSQL, Redis, in-memory.
+    Per-projection namespacing via the ``projection`` parameter.
+
+    Note:
+        Any ``ProjectionStore`` implementation automatically satisfies
+        ``ProjectionReadStore`` via structural subtyping.
+    """
+
+    async def save(self, projection: str, key: str, data: dict[str, Any]) -> None:
+        """Save or update a projection record.
+
+        Args:
+            projection: Name of the projection (e.g., "workflow_summaries")
+            key: Unique identifier for the record (usually aggregate ID)
+            data: Dictionary of field values to store
+        """
+        ...
+
+    async def get(self, projection: str, key: str) -> dict[str, Any] | None:
+        """Get a single projection record by key.
+
+        Args:
+            projection: Name of the projection
+            key: Unique identifier for the record
+
+        Returns:
+            Dictionary of field values, or None if not found
+        """
+        ...
+
+    async def get_all(self, projection: str) -> list[dict[str, Any]]:
+        """Get all records for a projection.
+
+        Args:
+            projection: Name of the projection
+
+        Returns:
+            List of dictionaries, one per record
+        """
+        ...
+
+    async def delete(self, projection: str, key: str) -> None:
+        """Delete a projection record.
+
+        Args:
+            projection: Name of the projection
+            key: Unique identifier for the record
+        """
+        ...
+
+    async def delete_all(self, projection: str) -> None:
+        """Delete all records for a projection (used for rebuilds).
+
+        Args:
+            projection: Name of the projection
+        """
+        ...
+
+    async def query(
+        self,
+        projection: str,
+        filters: dict[str, Any] | None = None,
+        order_by: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """Query projection records with optional filtering.
+
+        Args:
+            projection: Name of the projection
+            filters: Dictionary of field=value filters (exact match)
+            order_by: Field name to sort by (prefix with - for descending)
+            limit: Maximum number of records to return
+            offset: Number of records to skip
+
+        Returns:
+            List of matching dictionaries
+        """
+        ...
+
+    async def get_by_prefix(
+        self, projection: str, prefix: str
+    ) -> list[tuple[str, dict[str, Any]]]:
+        """Get all records whose key starts with the given prefix.
+
+        Args:
+            projection: Name of the projection
+            prefix: The key prefix to match against
+
+        Returns:
+            List of (key, data) tuples for matching records
+        """
+        ...
+
+
+@runtime_checkable
+class ProjectionReadStore(Protocol):
+    """Read-only subset of ``ProjectionStore`` for query handlers.
+
+    Query handlers that only read projection data should depend on
+    this protocol, not the full ``ProjectionStore``. Any ``ProjectionStore``
+    implementation automatically satisfies this protocol via structural
+    subtyping.
+    """
+
+    async def get(self, projection: str, key: str) -> dict[str, Any] | None:
+        """Get a single projection record by key.
+
+        Args:
+            projection: Name of the projection
+            key: Unique identifier for the record
+
+        Returns:
+            Dictionary of field values, or None if not found
+        """
+        ...
+
+    async def get_all(self, projection: str) -> list[dict[str, Any]]:
+        """Get all records for a projection.
+
+        Args:
+            projection: Name of the projection
+
+        Returns:
+            List of dictionaries, one per record
         """
         ...
 

--- a/event-sourcing/python/src/event_sourcing/stores/__init__.py
+++ b/event-sourcing/python/src/event_sourcing/stores/__init__.py
@@ -1,15 +1,20 @@
 """
-Checkpoint stores for projection position tracking.
+Store implementations for projection checkpoints and read-model data.
 
-This module provides implementations of ProjectionCheckpointStore:
+Checkpoint stores (ProjectionCheckpointStore):
 - PostgresCheckpointStore: Production-ready, ACID-compliant storage
 - MemoryCheckpointStore: For unit tests only (test environment enforced)
+
+Projection stores (ProjectionStore):
+- MemoryProjectionStore: For unit tests only (test environment enforced)
 """
 
 from event_sourcing.stores.memory_checkpoint import MemoryCheckpointStore
+from event_sourcing.stores.memory_projection import MemoryProjectionStore
 from event_sourcing.stores.postgres_checkpoint import PostgresCheckpointStore
 
 __all__ = [
-    "PostgresCheckpointStore",
     "MemoryCheckpointStore",
+    "MemoryProjectionStore",
+    "PostgresCheckpointStore",
 ]

--- a/event-sourcing/python/src/event_sourcing/stores/memory_projection.py
+++ b/event-sourcing/python/src/event_sourcing/stores/memory_projection.py
@@ -1,0 +1,122 @@
+"""
+In-memory implementation of ProjectionStore.
+
+This is for TEST ENVIRONMENTS ONLY (per ADR-004).
+"""
+
+import os
+from typing import Any
+
+from event_sourcing.core.checkpoint import ProjectionReadStore, ProjectionStore
+
+
+def _assert_test_environment() -> None:
+    """Ensure we are running in a test environment.
+
+    Per ADR-004, mock/in-memory implementations must validate they are
+    running in the test environment. This prevents accidental use in
+    production where data would be lost on restart.
+
+    Raises:
+        RuntimeError: If not in a test environment
+    """
+    is_test = (
+        os.getenv("PYTEST_CURRENT_TEST") is not None
+        or os.getenv("TEST_ENV") == "true"
+        or os.getenv("IS_TEST") == "true"
+        or os.getenv("NODE_ENV") == "test"
+        or os.getenv("ENVIRONMENT") == "test"
+    )
+
+    if not is_test:
+        raise RuntimeError(
+            "MemoryProjectionStore is for test environments only. "
+            "Set TEST_ENV=true or use a persistent ProjectionStore for production. "
+            "See ADR-004 for details."
+        )
+
+
+class MemoryProjectionStore:
+    """In-memory projection store for unit tests.
+
+    Stores projection read-model data in nested dictionaries.
+    Data is lost when the process exits.
+
+    Usage (in tests only):
+        store = MemoryProjectionStore()
+        await store.save("repo_cost", "org/repo", {"total": 42.0})
+        data = await store.get("repo_cost", "org/repo")
+    """
+
+    def __init__(self) -> None:
+        _assert_test_environment()
+        self._data: dict[str, dict[str, dict[str, Any]]] = {}
+
+    async def save(self, projection: str, key: str, data: dict[str, Any]) -> None:
+        """Save or update a projection record."""
+        if projection not in self._data:
+            self._data[projection] = {}
+        self._data[projection][key] = data
+
+    async def get(self, projection: str, key: str) -> dict[str, Any] | None:
+        """Get a single projection record by key."""
+        return self._data.get(projection, {}).get(key)
+
+    async def get_all(self, projection: str) -> list[dict[str, Any]]:
+        """Get all records for a projection."""
+        return list(self._data.get(projection, {}).values())
+
+    async def delete(self, projection: str, key: str) -> None:
+        """Delete a projection record."""
+        if projection in self._data:
+            self._data[projection].pop(key, None)
+
+    async def delete_all(self, projection: str) -> None:
+        """Delete all records for a projection."""
+        self._data.pop(projection, None)
+
+    async def query(
+        self,
+        projection: str,
+        filters: dict[str, Any] | None = None,
+        order_by: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """Query projection records with optional filtering."""
+        records = list(self._data.get(projection, {}).values())
+
+        if filters:
+            records = [
+                r for r in records if all(r.get(k) == v for k, v in filters.items())
+            ]
+
+        if order_by:
+            reverse = order_by.startswith("-")
+            field = order_by.lstrip("-")
+            records.sort(key=lambda r: r.get(field, ""), reverse=reverse)
+
+        records = records[offset:]
+        if limit is not None:
+            records = records[:limit]
+
+        return records
+
+    async def get_by_prefix(
+        self, projection: str, prefix: str
+    ) -> list[tuple[str, dict[str, Any]]]:
+        """Get all records whose key starts with the given prefix."""
+        results: list[tuple[str, dict[str, Any]]] = []
+        for key, data in self._data.get(projection, {}).items():
+            if key.startswith(prefix):
+                results.append((key, data))
+        return results
+
+    def clear(self) -> None:
+        """Clear all data (test utility)."""
+        self._data.clear()
+
+
+# Protocol compliance assertions (static check)
+_store: type[ProjectionStore] = MemoryProjectionStore
+_read_store: type[ProjectionReadStore] = MemoryProjectionStore

--- a/event-sourcing/python/tests/unit/test_projection_store.py
+++ b/event-sourcing/python/tests/unit/test_projection_store.py
@@ -1,0 +1,226 @@
+"""Tests for ProjectionStore and ProjectionReadStore protocols."""
+
+from typing import Any
+
+import pytest
+
+from event_sourcing.core.checkpoint import ProjectionReadStore, ProjectionStore
+
+
+# ============================================================================
+# Inline test implementation (mirrors the pattern in test_checkpoint.py)
+# ============================================================================
+
+
+class InMemoryStore:
+    """Minimal in-memory implementation for testing protocol compliance."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, dict[str, dict[str, Any]]] = {}
+
+    async def save(self, projection: str, key: str, data: dict[str, Any]) -> None:
+        if projection not in self._data:
+            self._data[projection] = {}
+        self._data[projection][key] = data
+
+    async def get(self, projection: str, key: str) -> dict[str, Any] | None:
+        return self._data.get(projection, {}).get(key)
+
+    async def get_all(self, projection: str) -> list[dict[str, Any]]:
+        return list(self._data.get(projection, {}).values())
+
+    async def delete(self, projection: str, key: str) -> None:
+        if projection in self._data:
+            self._data[projection].pop(key, None)
+
+    async def delete_all(self, projection: str) -> None:
+        self._data.pop(projection, None)
+
+    async def query(
+        self,
+        projection: str,
+        filters: dict[str, Any] | None = None,
+        order_by: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        records = list(self._data.get(projection, {}).values())
+        if filters:
+            records = [r for r in records if all(r.get(k) == v for k, v in filters.items())]
+        if order_by:
+            reverse = order_by.startswith("-")
+            field = order_by.lstrip("-")
+            records.sort(key=lambda r: r.get(field, ""), reverse=reverse)
+        records = records[offset:]
+        if limit is not None:
+            records = records[:limit]
+        return records
+
+    async def get_by_prefix(
+        self, projection: str, prefix: str
+    ) -> list[tuple[str, dict[str, Any]]]:
+        return [
+            (k, v)
+            for k, v in self._data.get(projection, {}).items()
+            if k.startswith(prefix)
+        ]
+
+
+# ============================================================================
+# Protocol compliance tests
+# ============================================================================
+
+
+class TestProjectionStoreProtocol:
+    """Tests for ProjectionStore protocol."""
+
+    def test_protocol_runtime_checkable(self) -> None:
+        """ProjectionStore should be runtime checkable."""
+        store = InMemoryStore()
+        assert isinstance(store, ProjectionStore)
+
+    def test_projection_store_satisfies_read_store(self) -> None:
+        """Any ProjectionStore should also satisfy ProjectionReadStore."""
+        store = InMemoryStore()
+        assert isinstance(store, ProjectionStore)
+        assert isinstance(store, ProjectionReadStore)
+
+    @pytest.mark.asyncio
+    async def test_save_and_get(self) -> None:
+        """Should save and retrieve a record."""
+        store = InMemoryStore()
+        data = {"total_cost": 42.5, "execution_count": 3}
+
+        await store.save("repo_cost", "org/repo", data)
+        result = await store.get("repo_cost", "org/repo")
+
+        assert result == data
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent(self) -> None:
+        """Should return None for nonexistent record."""
+        store = InMemoryStore()
+
+        result = await store.get("repo_cost", "nonexistent")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_all(self) -> None:
+        """Should return all records for a projection."""
+        store = InMemoryStore()
+        await store.save("repo_cost", "org/a", {"cost": 10})
+        await store.save("repo_cost", "org/b", {"cost": 20})
+
+        results = await store.get_all("repo_cost")
+
+        assert len(results) == 2
+        assert {"cost": 10} in results
+        assert {"cost": 20} in results
+
+    @pytest.mark.asyncio
+    async def test_get_all_empty(self) -> None:
+        """Should return empty list for nonexistent projection."""
+        store = InMemoryStore()
+
+        results = await store.get_all("nonexistent")
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_delete(self) -> None:
+        """Should delete a record."""
+        store = InMemoryStore()
+        await store.save("proj", "key1", {"val": 1})
+
+        await store.delete("proj", "key1")
+        result = await store.get("proj", "key1")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_delete_all(self) -> None:
+        """Should delete all records for a projection."""
+        store = InMemoryStore()
+        await store.save("proj", "key1", {"val": 1})
+        await store.save("proj", "key2", {"val": 2})
+
+        await store.delete_all("proj")
+        results = await store.get_all("proj")
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_query_with_filters(self) -> None:
+        """Should filter records by field values."""
+        store = InMemoryStore()
+        await store.save("executions", "e1", {"status": "completed", "cost": 10})
+        await store.save("executions", "e2", {"status": "failed", "cost": 5})
+        await store.save("executions", "e3", {"status": "completed", "cost": 20})
+
+        results = await store.query("executions", filters={"status": "completed"})
+
+        assert len(results) == 2
+        assert all(r["status"] == "completed" for r in results)
+
+    @pytest.mark.asyncio
+    async def test_query_with_limit_and_offset(self) -> None:
+        """Should support pagination via limit and offset."""
+        store = InMemoryStore()
+        for i in range(5):
+            await store.save("items", f"k{i}", {"index": i})
+
+        results = await store.query("items", offset=2, limit=2)
+
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_by_prefix(self) -> None:
+        """Should return records whose keys match a prefix."""
+        store = InMemoryStore()
+        await store.save("proj", "abc-1", {"val": 1})
+        await store.save("proj", "abc-2", {"val": 2})
+        await store.save("proj", "xyz-1", {"val": 3})
+
+        results = await store.get_by_prefix("proj", "abc")
+
+        assert len(results) == 2
+        keys = [k for k, _ in results]
+        assert "abc-1" in keys
+        assert "abc-2" in keys
+
+    @pytest.mark.asyncio
+    async def test_projection_namespacing(self) -> None:
+        """Records in different projections should be independent."""
+        store = InMemoryStore()
+        await store.save("proj_a", "key1", {"source": "a"})
+        await store.save("proj_b", "key1", {"source": "b"})
+
+        a = await store.get("proj_a", "key1")
+        b = await store.get("proj_b", "key1")
+
+        assert a == {"source": "a"}
+        assert b == {"source": "b"}
+
+
+class TestProjectionReadStoreProtocol:
+    """Tests for ProjectionReadStore protocol."""
+
+    def test_protocol_runtime_checkable(self) -> None:
+        """ProjectionReadStore should be runtime checkable."""
+        store = InMemoryStore()
+        assert isinstance(store, ProjectionReadStore)
+
+    def test_read_only_class_satisfies_protocol(self) -> None:
+        """A class with only get/get_all should satisfy ProjectionReadStore."""
+
+        class ReadOnlyStore:
+            async def get(self, projection: str, key: str) -> dict[str, Any] | None:
+                return None
+
+            async def get_all(self, projection: str) -> list[dict[str, Any]]:
+                return []
+
+        store = ReadOnlyStore()
+        assert isinstance(store, ProjectionReadStore)
+        assert not isinstance(store, ProjectionStore)

--- a/event-sourcing/python/tests/unit/test_projection_store.py
+++ b/event-sourcing/python/tests/unit/test_projection_store.py
@@ -6,7 +6,6 @@ import pytest
 
 from event_sourcing.core.checkpoint import ProjectionReadStore, ProjectionStore
 
-
 # ============================================================================
 # Inline test implementation (mirrors the pattern in test_checkpoint.py)
 # ============================================================================

--- a/event-sourcing/python/uv.lock
+++ b/event-sourcing/python/uv.lock
@@ -129,7 +129,7 @@ toml = [
 
 [[package]]
 name = "event-sourcing-python"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "protobuf" },

--- a/vsa/vsa-cli/src/templates/context.rs
+++ b/vsa/vsa-cli/src/templates/context.rs
@@ -376,6 +376,9 @@ mod tests {
             validation: ValidationConfig::default(),
             patterns: PatternsConfig::default(),
             projection_allowed_prefixes: None,
+            cross_context_scan_paths: Vec::new(),
+            exceptions: Vec::new(),
+            layer_separation: None,
         }
     }
 

--- a/vsa/vsa-cli/src/templates/engine.rs
+++ b/vsa/vsa-cli/src/templates/engine.rs
@@ -224,6 +224,9 @@ mod tests {
             validation: ValidationConfig::default(),
             patterns: PatternsConfig::default(),
             projection_allowed_prefixes: None,
+            cross_context_scan_paths: Vec::new(),
+            exceptions: Vec::new(),
+            layer_separation: None,
         }
     }
 
@@ -263,6 +266,9 @@ mod tests {
             validation: ValidationConfig::default(),
             patterns: PatternsConfig::default(),
             projection_allowed_prefixes: None,
+            cross_context_scan_paths: Vec::new(),
+            exceptions: Vec::new(),
+            layer_separation: None,
         }
     }
 

--- a/vsa/vsa-core/src/config.rs
+++ b/vsa/vsa-core/src/config.rs
@@ -63,6 +63,28 @@ pub struct VsaConfig {
     /// Exception budgets for grandfathered violations
     #[serde(default)]
     pub exceptions: Vec<ExceptionBudget>,
+
+    /// Layer separation enforcement configuration
+    #[serde(default)]
+    pub layer_separation: Option<LayerSeparationConfig>,
+}
+
+/// Configuration for layer separation enforcement (VSA206).
+///
+/// Defines which packages are forbidden from being imported by domain/slice
+/// code and adapter code. TYPE_CHECKING imports are automatically exempt
+/// (the import parser already filters them out).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct LayerSeparationConfig {
+    /// Packages that domain and slice code must not import at runtime.
+    /// Example: ["syn_adapters", "syn_api"]
+    #[serde(default)]
+    pub forbidden_domain_imports: Vec<String>,
+
+    /// Packages that adapter code must not import at runtime.
+    /// Example: ["syn_api"]
+    #[serde(default)]
+    pub forbidden_adapter_imports: Vec<String>,
 }
 
 /// Exception budget for a specific file+rule combination
@@ -1232,6 +1254,7 @@ mod tests {
             projection_allowed_prefixes: None,
             cross_context_scan_paths: Vec::new(),
             exceptions: Vec::new(),
+            layer_separation: None,
         };
 
         assert!(config.validate().is_ok());
@@ -1255,6 +1278,7 @@ mod tests {
             projection_allowed_prefixes: None,
             cross_context_scan_paths: Vec::new(),
             exceptions: Vec::new(),
+            layer_separation: None,
         };
 
         assert!(config.validate().is_ok());
@@ -1279,6 +1303,7 @@ mod tests {
             projection_allowed_prefixes: None,
             cross_context_scan_paths: Vec::new(),
             exceptions: Vec::new(),
+            layer_separation: None,
         };
 
         assert!(config.validate().is_err());
@@ -1301,6 +1326,7 @@ mod tests {
             projection_allowed_prefixes: None,
             cross_context_scan_paths: Vec::new(),
             exceptions: Vec::new(),
+            layer_separation: None,
         };
 
         assert!(config.validate().is_err());
@@ -1323,6 +1349,7 @@ mod tests {
             projection_allowed_prefixes: None,
             cross_context_scan_paths: Vec::new(),
             exceptions: Vec::new(),
+            layer_separation: None,
         };
 
         assert!(config.validate().is_err());

--- a/vsa/vsa-core/src/scanner.rs
+++ b/vsa/vsa-core/src/scanner.rs
@@ -174,6 +174,7 @@ mod tests {
             projection_allowed_prefixes: None,
             cross_context_scan_paths: Vec::new(),
             exceptions: Vec::new(),
+            layer_separation: None,
         }
     }
 

--- a/vsa/vsa-core/src/validation/bounded_context_rules.rs
+++ b/vsa/vsa-core/src/validation/bounded_context_rules.rs
@@ -362,6 +362,7 @@ mod tests {
             projection_allowed_prefixes: None,
             cross_context_scan_paths: Vec::new(),
             exceptions: Vec::new(),
+            layer_separation: None,
         }
     }
 

--- a/vsa/vsa-core/src/validation/cross_context_rules.rs
+++ b/vsa/vsa-core/src/validation/cross_context_rules.rs
@@ -402,6 +402,7 @@ mod tests {
             projection_allowed_prefixes: None,
             cross_context_scan_paths: Vec::new(),
             exceptions: Vec::new(),
+            layer_separation: None,
         }
     }
 

--- a/vsa/vsa-core/src/validation/dependency_rules.rs
+++ b/vsa/vsa-core/src/validation/dependency_rules.rs
@@ -1263,21 +1263,21 @@ impl LayerSeparationRule {
                 .to_string_lossy()
                 .to_string();
 
-            // Check exception budget for this file
-            let budget = ctx
+            // Check exception budget for this file (sum all matching entries)
+            let budget: usize = ctx
                 .config
                 .exceptions
                 .iter()
-                .find(|e| e.rule == "VSA206" && rel_path.ends_with(&e.file))
+                .filter(|e| e.rule == "VSA206" && rel_path.ends_with(&e.file))
                 .map(|e| e.budget)
-                .unwrap_or(0);
+                .sum();
 
             let mut violation_count = 0usize;
 
             for import in &imports {
                 let module = import.module.replace("::", ".").replace('/', ".");
                 for pkg in forbidden {
-                    if module.starts_with(pkg) {
+                    if module == *pkg || module.starts_with(&format!("{pkg}.")) {
                         violation_count += 1;
                         if violation_count > budget {
                             report.errors.push(ValidationIssue {
@@ -1503,5 +1503,36 @@ mod layer_separation_tests {
 
         rule.validate(&ctx, &mut report).unwrap();
         assert_eq!(report.errors.len(), 0, "Test files should be exempt");
+    }
+
+    #[test]
+    fn test_module_boundary_no_false_positive() {
+        let temp_dir = TempDir::new().unwrap();
+        let ctx_path = temp_dir.path().join("myctx");
+        std::fs::create_dir_all(ctx_path.join("domain")).unwrap();
+        std::fs::create_dir_all(ctx_path.join("slices/cost")).unwrap();
+
+        // "syn_adapters_extra" should NOT match forbidden "syn_adapters"
+        std::fs::write(
+            ctx_path.join("domain/handler.py"),
+            "from syn_adapters_extra.utils import helper\n",
+        )
+        .unwrap();
+
+        let mut config = make_config(&temp_dir);
+        config.layer_separation = Some(crate::config::LayerSeparationConfig {
+            forbidden_domain_imports: vec!["syn_adapters".to_string()],
+            forbidden_adapter_imports: Vec::new(),
+        });
+        let ctx = ValidationContext::new(config, temp_dir.path().to_path_buf());
+        let rule = LayerSeparationRule;
+        let mut report = EnhancedValidationReport::default();
+
+        rule.validate(&ctx, &mut report).unwrap();
+        assert_eq!(
+            report.errors.len(),
+            0,
+            "Package prefix match should respect module boundaries"
+        );
     }
 }

--- a/vsa/vsa-core/src/validation/dependency_rules.rs
+++ b/vsa/vsa-core/src/validation/dependency_rules.rs
@@ -643,6 +643,7 @@ mod tests {
             projection_allowed_prefixes: None,
             cross_context_scan_paths: Vec::new(),
             exceptions: Vec::new(),
+            layer_separation: None,
         };
         let ctx = ValidationContext::new(config, temp_dir.path().to_path_buf());
         (temp_dir, ctx)
@@ -1008,6 +1009,7 @@ mod tests {
             projection_allowed_prefixes: None,
             cross_context_scan_paths: Vec::new(),
             exceptions: Vec::new(),
+            layer_separation: None,
         };
         config.validation.exclude_from_isolation =
             vec!["list_repos".to_string()];
@@ -1057,6 +1059,7 @@ mod tests {
             projection_allowed_prefixes: None,
             cross_context_scan_paths: Vec::new(),
             exceptions: Vec::new(),
+            layer_separation: None,
         };
         // Exclude list_repos but NOT other_slice
         config.validation.exclude_from_isolation =
@@ -1116,5 +1119,389 @@ mod tests {
         // but our validation now checks if target is a real slice directory
         let result = SliceIsolationRule::extract_slice_name("slices.conftest");
         assert_eq!(result, Some("conftest".to_string()));
+    }
+}
+
+// ============================================================================
+// VSA206: Layer Separation Rule
+// ============================================================================
+
+/// Rule: Domain/slice code must not import from configurable forbidden packages.
+///
+/// Enforces hexagonal architecture boundaries by preventing domain and slice code
+/// from importing adapter-layer or API-layer packages directly. TYPE_CHECKING
+/// imports are automatically exempt (the import parser already filters them).
+///
+/// Configured via `layer_separation` in vsa.yaml:
+/// ```yaml
+/// layer_separation:
+///   forbidden_domain_imports: ["syn_adapters", "syn_api"]
+///   forbidden_adapter_imports: ["syn_api"]
+/// ```
+pub struct LayerSeparationRule;
+
+impl ValidationRule for LayerSeparationRule {
+    fn name(&self) -> &str {
+        "layer-separation"
+    }
+
+    fn code(&self) -> &str {
+        "VSA206"
+    }
+
+    fn validate(
+        &self,
+        ctx: &ValidationContext,
+        report: &mut EnhancedValidationReport,
+    ) -> Result<()> {
+        let config = match &ctx.config.layer_separation {
+            Some(c) => c,
+            None => return Ok(()), // No config = rule is a no-op
+        };
+
+        if config.forbidden_domain_imports.is_empty() && config.forbidden_adapter_imports.is_empty()
+        {
+            return Ok(());
+        }
+
+        let scanner = Scanner::new(ctx.config.clone(), ctx.root.clone());
+        let contexts = scanner.scan_contexts()?;
+
+        // Check domain and slice code against forbidden_domain_imports
+        if !config.forbidden_domain_imports.is_empty() {
+            for context in &contexts {
+                self.check_layer_files(
+                    ctx,
+                    report,
+                    &context.path.join("domain"),
+                    &config.forbidden_domain_imports,
+                    "Domain",
+                )?;
+                self.check_layer_files(
+                    ctx,
+                    report,
+                    &context.path.join("slices"),
+                    &config.forbidden_domain_imports,
+                    "Slice",
+                )?;
+            }
+        }
+
+        // Check adapter/infrastructure code against forbidden_adapter_imports
+        if !config.forbidden_adapter_imports.is_empty() {
+            for context in &contexts {
+                self.check_layer_files(
+                    ctx,
+                    report,
+                    &context.path.join("infrastructure"),
+                    &config.forbidden_adapter_imports,
+                    "Infrastructure",
+                )?;
+            }
+
+            // Also check cross_context_scan_paths (adapter packages outside context root)
+            for scan_path in &ctx.config.cross_context_scan_paths {
+                let abs_path = ctx.root.join(scan_path);
+                if abs_path.exists() {
+                    self.check_layer_files(
+                        ctx,
+                        report,
+                        &abs_path,
+                        &config.forbidden_adapter_imports,
+                        "Adapter",
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl LayerSeparationRule {
+    fn check_layer_files(
+        &self,
+        ctx: &ValidationContext,
+        report: &mut EnhancedValidationReport,
+        dir: &std::path::Path,
+        forbidden: &[String],
+        layer_name: &str,
+    ) -> Result<()> {
+        if !dir.exists() {
+            return Ok(());
+        }
+
+        for entry in walkdir::WalkDir::new(dir)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().is_file())
+            .filter(|e| !is_test_or_conftest(e.path()))
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .map_or(false, |ext| ext == "py" || ext == "ts" || ext == "rs")
+            })
+        {
+            let file_path = entry.path();
+
+            // Skip __init__.py (public API definitions)
+            if file_path
+                .file_name()
+                .map_or(false, |n| n == "__init__.py")
+            {
+                continue;
+            }
+
+            let imports = match parse_imports(file_path) {
+                Ok(i) => i,
+                Err(_) => continue,
+            };
+
+            let rel_path = file_path
+                .strip_prefix(&ctx.root)
+                .unwrap_or(file_path)
+                .to_string_lossy()
+                .to_string();
+
+            // Check exception budget for this file
+            let budget = ctx
+                .config
+                .exceptions
+                .iter()
+                .find(|e| e.rule == "VSA206" && rel_path.ends_with(&e.file))
+                .map(|e| e.budget)
+                .unwrap_or(0);
+
+            let mut violation_count = 0usize;
+
+            for import in &imports {
+                let module = import.module.replace("::", ".").replace('/', ".");
+                for pkg in forbidden {
+                    if module.starts_with(pkg) {
+                        violation_count += 1;
+                        if violation_count > budget {
+                            report.errors.push(ValidationIssue {
+                                path: file_path.to_path_buf(),
+                                code: self.code().to_string(),
+                                severity: Severity::Error,
+                                message: format!(
+                                    "{} file '{}' imports forbidden package '{}': '{}' (line {})",
+                                    layer_name,
+                                    rel_path,
+                                    pkg,
+                                    import.module,
+                                    import.line_number,
+                                ),
+                                suggestions: vec![
+                                    Suggestion::manual(
+                                        "Import from the framework (event_sourcing) instead",
+                                    ),
+                                    Suggestion::manual(
+                                        "Define a port interface in the domain layer",
+                                    ),
+                                ],
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod layer_separation_tests {
+    use super::*;
+    use crate::config::*;
+    use tempfile::TempDir;
+
+    fn make_config(temp_dir: &TempDir) -> VsaConfig {
+        VsaConfig {
+            version: 2,
+            architecture: ArchitectureType::VerticalSlice,
+            root: temp_dir.path().to_path_buf(),
+            language: "python".to_string(),
+            domain: Some(DomainConfig::default()),
+            slices: Some(SlicesConfig::default()),
+            infrastructure: None,
+            framework: None,
+            contexts: std::collections::HashMap::new(),
+            validation: ValidationConfig::default(),
+            patterns: PatternsConfig::default(),
+            projection_allowed_prefixes: None,
+            cross_context_scan_paths: Vec::new(),
+            exceptions: Vec::new(),
+            layer_separation: None,
+        }
+    }
+
+    #[test]
+    fn test_no_config_is_noop() {
+        let temp_dir = TempDir::new().unwrap();
+        let ctx_path = temp_dir.path().join("myctx");
+        std::fs::create_dir_all(ctx_path.join("domain")).unwrap();
+        std::fs::create_dir_all(ctx_path.join("slices/my_slice")).unwrap();
+
+        std::fs::write(
+            ctx_path.join("slices/my_slice/handler.py"),
+            "from syn_adapters.projection_stores.protocol import ProjectionStoreProtocol\n",
+        )
+        .unwrap();
+
+        let config = make_config(&temp_dir);
+        let ctx = ValidationContext::new(config, temp_dir.path().to_path_buf());
+        let rule = LayerSeparationRule;
+        let mut report = EnhancedValidationReport::default();
+
+        rule.validate(&ctx, &mut report).unwrap();
+        assert_eq!(report.errors.len(), 0, "No config means no violations");
+    }
+
+    #[test]
+    fn test_forbidden_domain_import_detected() {
+        let temp_dir = TempDir::new().unwrap();
+        let ctx_path = temp_dir.path().join("myctx");
+        std::fs::create_dir_all(ctx_path.join("domain")).unwrap();
+        std::fs::create_dir_all(ctx_path.join("slices/my_slice")).unwrap();
+
+        // Domain file importing from forbidden package
+        std::fs::write(
+            ctx_path.join("domain/handler.py"),
+            "from syn_adapters.projection_stores.protocol import ProjectionStoreProtocol\n",
+        )
+        .unwrap();
+
+        let mut config = make_config(&temp_dir);
+        config.layer_separation = Some(crate::config::LayerSeparationConfig {
+            forbidden_domain_imports: vec!["syn_adapters".to_string()],
+            forbidden_adapter_imports: Vec::new(),
+        });
+        let ctx = ValidationContext::new(config, temp_dir.path().to_path_buf());
+        let rule = LayerSeparationRule;
+        let mut report = EnhancedValidationReport::default();
+
+        rule.validate(&ctx, &mut report).unwrap();
+        assert_eq!(report.errors.len(), 1);
+        assert_eq!(report.errors[0].code, "VSA206");
+        assert!(report.errors[0].message.contains("syn_adapters"));
+    }
+
+    #[test]
+    fn test_forbidden_slice_import_detected() {
+        let temp_dir = TempDir::new().unwrap();
+        let ctx_path = temp_dir.path().join("myctx");
+        std::fs::create_dir_all(ctx_path.join("domain")).unwrap();
+        std::fs::create_dir_all(ctx_path.join("slices/cost")).unwrap();
+
+        // Slice file importing from forbidden package
+        std::fs::write(
+            ctx_path.join("slices/cost/handler.py"),
+            "from syn_adapters.projection_stores.protocol import ProjectionStoreProtocol\n",
+        )
+        .unwrap();
+
+        let mut config = make_config(&temp_dir);
+        config.layer_separation = Some(crate::config::LayerSeparationConfig {
+            forbidden_domain_imports: vec!["syn_adapters".to_string()],
+            forbidden_adapter_imports: Vec::new(),
+        });
+        let ctx = ValidationContext::new(config, temp_dir.path().to_path_buf());
+        let rule = LayerSeparationRule;
+        let mut report = EnhancedValidationReport::default();
+
+        rule.validate(&ctx, &mut report).unwrap();
+        assert_eq!(report.errors.len(), 1);
+        assert_eq!(report.errors[0].code, "VSA206");
+    }
+
+    #[test]
+    fn test_allowed_framework_import_passes() {
+        let temp_dir = TempDir::new().unwrap();
+        let ctx_path = temp_dir.path().join("myctx");
+        std::fs::create_dir_all(ctx_path.join("domain")).unwrap();
+        std::fs::create_dir_all(ctx_path.join("slices/cost")).unwrap();
+
+        // Domain file importing from allowed framework package
+        std::fs::write(
+            ctx_path.join("domain/handler.py"),
+            "from event_sourcing import ProjectionReadStore\n",
+        )
+        .unwrap();
+
+        let mut config = make_config(&temp_dir);
+        config.layer_separation = Some(crate::config::LayerSeparationConfig {
+            forbidden_domain_imports: vec!["syn_adapters".to_string()],
+            forbidden_adapter_imports: Vec::new(),
+        });
+        let ctx = ValidationContext::new(config, temp_dir.path().to_path_buf());
+        let rule = LayerSeparationRule;
+        let mut report = EnhancedValidationReport::default();
+
+        rule.validate(&ctx, &mut report).unwrap();
+        assert_eq!(report.errors.len(), 0, "Framework imports should be allowed");
+    }
+
+    #[test]
+    fn test_exception_budget_respected() {
+        let temp_dir = TempDir::new().unwrap();
+        let ctx_path = temp_dir.path().join("myctx");
+        std::fs::create_dir_all(ctx_path.join("domain")).unwrap();
+        std::fs::create_dir_all(ctx_path.join("slices/cost")).unwrap();
+
+        std::fs::write(
+            ctx_path.join("slices/cost/handler.py"),
+            "from syn_adapters.projection_stores.protocol import ProjectionStoreProtocol\n",
+        )
+        .unwrap();
+
+        let mut config = make_config(&temp_dir);
+        config.layer_separation = Some(crate::config::LayerSeparationConfig {
+            forbidden_domain_imports: vec!["syn_adapters".to_string()],
+            forbidden_adapter_imports: Vec::new(),
+        });
+        config.exceptions = vec![ExceptionBudget {
+            file: "slices/cost/handler.py".to_string(),
+            rule: "VSA206".to_string(),
+            budget: 1,
+            issue: Some("#197".to_string()),
+        }];
+        let ctx = ValidationContext::new(config, temp_dir.path().to_path_buf());
+        let rule = LayerSeparationRule;
+        let mut report = EnhancedValidationReport::default();
+
+        rule.validate(&ctx, &mut report).unwrap();
+        assert_eq!(
+            report.errors.len(),
+            0,
+            "Violation within budget should not be reported"
+        );
+    }
+
+    #[test]
+    fn test_test_files_exempt() {
+        let temp_dir = TempDir::new().unwrap();
+        let ctx_path = temp_dir.path().join("myctx");
+        std::fs::create_dir_all(ctx_path.join("domain")).unwrap();
+        std::fs::create_dir_all(ctx_path.join("slices/cost")).unwrap();
+
+        std::fs::write(
+            ctx_path.join("slices/cost/test_handler.py"),
+            "from syn_adapters.projection_stores.protocol import ProjectionStoreProtocol\n",
+        )
+        .unwrap();
+
+        let mut config = make_config(&temp_dir);
+        config.layer_separation = Some(crate::config::LayerSeparationConfig {
+            forbidden_domain_imports: vec!["syn_adapters".to_string()],
+            forbidden_adapter_imports: Vec::new(),
+        });
+        let ctx = ValidationContext::new(config, temp_dir.path().to_path_buf());
+        let rule = LayerSeparationRule;
+        let mut report = EnhancedValidationReport::default();
+
+        rule.validate(&ctx, &mut report).unwrap();
+        assert_eq!(report.errors.len(), 0, "Test files should be exempt");
     }
 }

--- a/vsa/vsa-core/src/validation/integration_event_rules.rs
+++ b/vsa/vsa-core/src/validation/integration_event_rules.rs
@@ -162,6 +162,7 @@ mod tests {
             projection_allowed_prefixes: None,
             cross_context_scan_paths: Vec::new(),
             exceptions: Vec::new(),
+            layer_separation: None,
         }
     }
 

--- a/vsa/vsa-core/src/validation/isolation_rules.rs
+++ b/vsa/vsa-core/src/validation/isolation_rules.rs
@@ -436,6 +436,7 @@ mod tests {
             projection_allowed_prefixes: None,
             cross_context_scan_paths: Vec::new(),
             exceptions: Vec::new(),
+            layer_separation: None,
         }
     }
 

--- a/vsa/vsa-core/src/validation/query_slice_rules.rs
+++ b/vsa/vsa-core/src/validation/query_slice_rules.rs
@@ -225,6 +225,7 @@ mod tests {
             projection_allowed_prefixes: None,
             cross_context_scan_paths: Vec::new(),
             exceptions: Vec::new(),
+            layer_separation: None,
         }
     }
 

--- a/vsa/vsa-core/src/validation/rules.rs
+++ b/vsa/vsa-core/src/validation/rules.rs
@@ -90,6 +90,8 @@ impl ValidationRuleSet {
             // Cross-context boundary rules
             Box::new(CrossContextPublicApiRule),      // VSA204
             Box::new(ContextPublicApiExistsRule),     // VSA205
+            // Layer separation rules
+            Box::new(super::dependency_rules::LayerSeparationRule),  // VSA206
             // Slice isolation rules (legacy)
             Box::new(NoCrossSliceImportsRule),
             Box::new(ThinAdapterRule),

--- a/vsa/vsa-core/src/validation/slice_location_rules.rs
+++ b/vsa/vsa-core/src/validation/slice_location_rules.rs
@@ -208,6 +208,7 @@ mod tests {
             projection_allowed_prefixes: None,
             cross_context_scan_paths: Vec::new(),
             exceptions: Vec::new(),
+            layer_separation: None,
         }
     }
 

--- a/vsa/vsa-core/src/validation/structure_rules.rs
+++ b/vsa/vsa-core/src/validation/structure_rules.rs
@@ -1445,6 +1445,7 @@ mod tests {
             projection_allowed_prefixes: None,
             cross_context_scan_paths: Vec::new(),
             exceptions: Vec::new(),
+            layer_separation: None,
         }
     }
 

--- a/vsa/vsa-core/src/validator.rs
+++ b/vsa/vsa-core/src/validator.rs
@@ -179,6 +179,7 @@ mod tests {
             projection_allowed_prefixes: None,
             cross_context_scan_paths: Vec::new(),
             exceptions: Vec::new(),
+            layer_separation: None,
         }
     }
 


### PR DESCRIPTION
## Summary

- **Python SDK**: Add `ProjectionStore` and `ProjectionReadStore` protocols to `event_sourcing.core.checkpoint`, with `MemoryProjectionStore` test implementation and 14 unit tests. Version bump to 0.13.0.
- **VSA**: Add VSA206 `LayerSeparationRule` - configurable forbidden import enforcement for domain/adapter layer separation. 6 unit tests.

## Motivation

syntropic137 filled a gap in the ESP SDK by creating `ProjectionStoreProtocol` in its adapter layer. This caused 11 domain query handlers to import from the adapter package - a layer violation. Rather than adding per-context ports, we're adding the missing abstraction to ESP so all consumers benefit.

`ProjectionStore` complements the existing `ProjectionCheckpointStore` (position tracking) with actual read-model data storage. `ProjectionReadStore` is the read-only subset for query handlers that only need `get()` and `get_all()`.

VSA206 enforces layer separation boundaries via `vsa.yaml` configuration, preventing domain code from importing adapter/API packages at runtime.

## Changes

### Python SDK (0.13.0)
- `ProjectionStore` protocol (7 methods: save, get, get_all, delete, delete_all, query, get_by_prefix)
- `ProjectionReadStore` protocol (2 methods: get, get_all) - structural subtype of ProjectionStore
- `MemoryProjectionStore` - in-memory test implementation with `_assert_test_environment()` guard
- Exported from `event_sourcing` top-level and `event_sourcing.stores`

### VSA (VSA206)
- `LayerSeparationConfig` in `config.rs` with `forbidden_domain_imports` and `forbidden_adapter_imports`
- `LayerSeparationRule` validates domain/slice files don't import forbidden packages
- Respects TYPE_CHECKING blocks (via existing parser), test files, and exception budgets
- No-op when config is absent

## Test plan
- [x] 14 Python unit tests (protocol compliance, CRUD, query, namespacing, structural subtyping)
- [x] 6 Rust unit tests (no-config noop, forbidden imports detected, allowed imports pass, exception budgets, test file exemption)
- [x] `uv run pytest` - 208 tests pass
- [x] `cargo test --lib` - 274 tests pass